### PR TITLE
Request to publish photo and video media

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This lib supports making requests to most of the Instagram Graph API resources. 
 -   `Recently Searched Hashtags` in the `IG User` node.
 -   `Stories` in the `IG User` node
 -   `Mentions`, `Mentioned Comments` and `Mentioned Media` in the `IG User` node.
--   `IG Container` and `Media Publish`.
 -   Webhooks.
 
 As it currently stands, this lib allows you to get a lot of information about your page and media, including basic information and insights. It also allows you to create and reply to comments, delete them and hide them.
@@ -87,9 +86,19 @@ let config: RequestConfig = request.config();
 [...]
 ```
 
+### Publishing media
+
+Publishing Media through the Instagram Graph API, and conversely through this lib, follows these steps:
+
+1. Create an IG Container object (through the `PostPagePhotoMediaRequest` or the `PostPageVideoMediaRequest`).
+2. Wait for the IG Container status to move to `FINISHED` (check the status through the `GetContainerRequest`).
+3. Publish the IG Container (through the `PostPublishMediaRequest`).
+
+For more info on this flow, refer to the [Content Publishing documentation](https://developers.facebook.com/docs/instagram-api/guides/content-publishing).
+
 ### Other request options
 
-You can give paging and range options to the requests, as supported by certain resources on the Instagram Graph API. (check the [reference documentation](<(https://developers.facebook.com/docs/instagram-api/reference/)>) to see which ones do). For example, the Get Page Media request supports paging, here's a naive example of how to use:
+You can give paging and range options to the requests, as supported by certain resources on the Instagram Graph API. (check the [reference documentation](https://developers.facebook.com/docs/instagram-api/reference/) to see which ones do). For example, the Get Page Media request supports paging, here's a naive example of how to use:
 
 ```typescript
 import { GetPageMediaRequest, GetPageMediaResponse, PageOption } from 'instagram-graph-api';

--- a/changelog/next_release.md
+++ b/changelog/next_release.md
@@ -1,0 +1,7 @@
+# `next.release`
+
+## Added
+
+-   `PostPagePhotoMediaRequest` and `PostPageVideoMediaRequest` to create media containers.
+-   `PostPublishMediaRequest` to publish the containers created through the previous requests.
+-   `GetContainerRequest` to get the status of a created container.

--- a/src/main/Client.ts
+++ b/src/main/Client.ts
@@ -32,6 +32,7 @@ import { GetPageMonthInsightsRequest } from './requests/page/insights/GetPageMon
 import { GetPageWeekInsightsRequest } from './requests/page/insights/GetPageWeekInsightsRequest';
 import { GetPageMediaRequest } from './requests/page/media/GetPageMediaRequest';
 import { PostPagePhotoMediaRequest } from './requests/page/media/PostPagePhotoMediaRequest';
+import { PostPageVideoMediaRequest } from './requests/page/media/PostPageVideoMediaRequest';
 import { PostPublishMediaRequest } from './requests/page/media_publish/PostPublishMediaRequest';
 import { GetTagsRequest } from './requests/page/tags/GetTagsRequest';
 import { UserTag } from './requests/Params';
@@ -367,6 +368,25 @@ export class Client {
         userTags?: UserTag[]
     ): PostPagePhotoMediaRequest {
         return new PostPagePhotoMediaRequest(this.accessToken, this.pageId, imageUrl, caption, locationId, userTags);
+    }
+
+    /**
+     * Build a new {@link PostPageVideoMediaRequest}.
+     *
+     * @param videoUrl the image URL.
+     * @param caption the caption.
+     * @param thumbOffset the thumbnail offset time in milliseconds.
+     * @param locationId the location id.
+     *
+     * @returns a new {@link PostPageVideoMediaRequest}.
+     */
+    public newPostPageVideoMediaRequest(
+        videoUrl: string,
+        caption?: string,
+        thumbOffset?: number,
+        locationId?: string
+    ): PostPageVideoMediaRequest {
+        return new PostPageVideoMediaRequest(this.accessToken, this.pageId, videoUrl, caption, thumbOffset, locationId);
     }
 
     /**

--- a/src/main/Client.ts
+++ b/src/main/Client.ts
@@ -1,5 +1,6 @@
 import {
     CommentField,
+    ContainerField,
     DayMetric,
     LifetimeMetric,
     MediaField,
@@ -14,6 +15,7 @@ import { GetCommentRequest } from './requests/comment/GetCommentRequest';
 import { PostHideCommentRequest } from './requests/comment/PostHideCommentRequest';
 import { GetRepliesRequest } from './requests/comment/replies/GetRepliesRequest';
 import { PostReplyRequest } from './requests/comment/replies/PostReplyRequest';
+import { GetContainerRequest } from './requests/container/GetContainerRequest';
 import { GetHashtagRecentMediaRequest } from './requests/hashtag/media/GetHashtagRecentMediaRequest';
 import { GetHashtagTopMediaRequest } from './requests/hashtag/media/GetHashtagTopMediaRequest';
 import { GetHashtagIdRequest } from './requests/hashtag/search/GetHashtagIdRequest';
@@ -29,7 +31,10 @@ import { GetPageLifetimeInsightsRequest } from './requests/page/insights/GetPage
 import { GetPageMonthInsightsRequest } from './requests/page/insights/GetPageMonthInsightsRequest';
 import { GetPageWeekInsightsRequest } from './requests/page/insights/GetPageWeekInsightsRequest';
 import { GetPageMediaRequest } from './requests/page/media/GetPageMediaRequest';
+import { PostPagePhotoMediaRequest } from './requests/page/media/PostPagePhotoMediaRequest';
+import { PostPublishMediaRequest } from './requests/page/media_publish/PostPublishMediaRequest';
 import { GetTagsRequest } from './requests/page/tags/GetTagsRequest';
+import { UserTag } from './requests/Params';
 
 /**
  * A client that creating requests.
@@ -331,5 +336,47 @@ export class Client {
      */
     public newGetTagsRequest(...fields: PublicMediaField[]): GetTagsRequest {
         return new GetTagsRequest(this.accessToken, this.pageId, ...fields);
+    }
+
+    /**
+     * Builds a new {@link GetContainerRequest}.
+     *
+     * @param containerId the container id.
+     * @param fields the fields to retrieve from the API.
+     *
+     * @returns a new {@link GetCommentRequest}.
+     */
+    public newGetContainerRequest(containerId: string, ...fields: ContainerField[]): GetContainerRequest {
+        return new GetContainerRequest(this.accessToken, containerId, ...fields);
+    }
+
+    /**
+     * Build a new {@link PostPagePhotoMediaRequest}.
+     *
+     * @param imageUrl the image URL.
+     * @param caption the caption.
+     * @param locationId the location id.
+     * @param userTags the user_tags.
+     *
+     * @returns a new {@link PostPagePhotoMediaRequest}.
+     */
+    public newPostPagePhotoMediaRequest(
+        imageUrl: string,
+        caption?: string,
+        locationId?: string,
+        userTags?: UserTag[]
+    ): PostPagePhotoMediaRequest {
+        return new PostPagePhotoMediaRequest(this.accessToken, this.pageId, imageUrl, caption, locationId, userTags);
+    }
+
+    /**
+     * Builds a new {@link PostPublishMediaRequest}.
+     *
+     * @param containerId the container id.
+     *
+     * @returns a new {@link PostPublishMediaRequest}.
+     */
+    public newPostPublishMediaRequest(containerId: string): PostPublishMediaRequest {
+        return new PostPublishMediaRequest(this.accessToken, this.pageId, containerId);
     }
 }

--- a/src/main/Enums.ts
+++ b/src/main/Enums.ts
@@ -418,3 +418,26 @@ export enum CommentField {
      */
     USERNAME = 'username',
 }
+
+/**
+ * Container fields that can be retrieved through Get Container requests.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since `next.release`
+ */
+export enum ContainerField {
+    /**
+     * The id of the container.
+     */
+    ID = 'id',
+
+    /**
+     * Publishing status. If status_code is ERROR, this value will be an error subcode.
+     */
+    STATUS = 'status',
+
+    /**
+     * The container's publishing status.
+     */
+    STATUS_CODE = 'status_code',
+}

--- a/src/main/requests/Params.ts
+++ b/src/main/requests/Params.ts
@@ -32,6 +32,7 @@ export interface Params {
     user_tags?: UserTag[];
     thumb_offset?: number;
     video_url?: string;
+    media_type?: 'video';
     /**
      * Not obtainable through this API. https://developers.facebook.com/docs/instagram-api/reference/ig-user/media
      */

--- a/src/main/requests/Params.ts
+++ b/src/main/requests/Params.ts
@@ -1,4 +1,13 @@
 /**
+ * Represents a user tag in a media object.
+ */
+export type UserTag = {
+    username: string;
+    x: number;
+    y: number;
+};
+
+/**
  * Interface to represent the params of a request.
  *
  * @author Tiago Grosso <tiagogrosso99@gmail.com>
@@ -18,4 +27,14 @@ export interface Params {
     q?: string;
     message?: string;
     hide?: boolean;
+    image_url?: string;
+    caption?: string;
+    user_tags?: UserTag[];
+    thumb_offset?: number;
+    video_url?: string;
+    /**
+     * Not obtainable through this API. https://developers.facebook.com/docs/instagram-api/reference/ig-user/media
+     */
+    location_id?: string;
+    creation_id?: string;
 }

--- a/src/main/requests/container/GetContainerRequest.ts
+++ b/src/main/requests/container/GetContainerRequest.ts
@@ -1,0 +1,46 @@
+import { AxiosResponse } from 'axios';
+import { ContainerField } from '../../Enums';
+import { AbstractRequest } from '../AbstractRequest';
+import { ContainerData } from '../data/ContainerData';
+import { GetContainerResponse } from './GetContainerResponse';
+
+/**
+ * A request that gets info about a container
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since `next.release`
+ */
+export class GetContainerRequest extends AbstractRequest<GetContainerResponse> {
+    /**
+     * The container id.
+     */
+    private containerId: string;
+
+    /**
+     * The constructor.
+     *
+     * @param accessToken the access token.
+     * @param containerId the container id.
+     * @param fields the set of container fields to retrieve from the API.
+     */
+    constructor(accessToken: string, containerId: string, ...fields: ContainerField[]) {
+        super(accessToken);
+        this.containerId = containerId;
+        const fieldsSet: Set<string> = fields.length > 0 ? new Set(fields) : new Set(Object.values(ContainerField));
+        this.params.fields = Array.from(fieldsSet).join(',');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected parseResponse(response: AxiosResponse<ContainerData>): GetContainerResponse {
+        return new GetContainerResponse(response.data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected url(): string {
+        return `/${this.containerId}`;
+    }
+}

--- a/src/main/requests/container/GetContainerResponse.ts
+++ b/src/main/requests/container/GetContainerResponse.ts
@@ -1,0 +1,37 @@
+import { AbstractResponse } from '../AbstractResponse';
+import { ContainerData, CONTAINER_STATUS_CODE } from '../data/ContainerData';
+
+/**
+ * Class that represents a response from a Get Container request.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since `next.release`
+ */
+export class GetContainerResponse extends AbstractResponse<ContainerData> {
+    /**
+     * Gets the container id.
+     *
+     * @returns the container id.
+     */
+    public getContainerId(): string {
+        return this.data.id;
+    }
+
+    /**
+     * Gets the container stauts.
+     *
+     * @returns the container stauts.
+     */
+    public getContainerStatus(): string | undefined {
+        return this.data.status;
+    }
+
+    /**
+     * Gets the the container status code.
+     *
+     * @returns the container status code.
+     */
+    public getContainerStatusCode(): CONTAINER_STATUS_CODE | undefined {
+        return this.data.status_code;
+    }
+}

--- a/src/main/requests/data/ContainerData.ts
+++ b/src/main/requests/data/ContainerData.ts
@@ -1,0 +1,55 @@
+/**
+ * Possible status codes for the container.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since `next.release`
+ */
+export enum CONTAINER_STATUS_CODE {
+    /**
+     * The container was not published within 24 hours and has expired.
+     */
+    EXPIRED,
+
+    /**
+     * The container failed to complete the publishing process.
+     */
+    ERROR,
+
+    /**
+     * The container and its media object are ready to be published.
+     */
+    FINISHED,
+
+    /**
+     * The container is still in the publishing process.
+     */
+    IN_PROGRESS,
+
+    /**
+     * The container's media object has been published.
+     */
+    PUBLISHED,
+}
+
+/**
+ * Interface to represent the data regarding a container.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since `next.release`
+ */
+export interface ContainerData {
+    /**
+     * The container id.
+     */
+    id: string;
+
+    /**
+     * The publishing status of the container.
+     */
+    status?: string;
+
+    /**
+     * The publishing status code of the container.
+     */
+    status_code?: CONTAINER_STATUS_CODE;
+}

--- a/src/main/requests/data/MeData.ts
+++ b/src/main/requests/data/MeData.ts
@@ -1,4 +1,16 @@
+/**
+ * Interface to represent the data regarding a Get Me Request.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since 1.0.0
+ */
 export interface MeData {
+    /**
+     * The instagram business account.
+     */
     instagram_business_account?: { id: string };
+    /**
+     * The page id.
+     */
     id: string;
 }

--- a/src/main/requests/page/media/PostPagePhotoMediaRequest.ts
+++ b/src/main/requests/page/media/PostPagePhotoMediaRequest.ts
@@ -1,0 +1,101 @@
+import { AxiosResponse } from 'axios';
+import { AbstractRequest } from '../../AbstractRequest';
+import { CreatedObjectIdResponse } from '../../common/CreatedObjectIdResponse';
+import { UserTag } from '../../Params';
+import { Method } from '../../RequestConfig';
+
+/**
+ * A request that creates a new Photo Media.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since `next.release`
+ */
+export class PostPagePhotoMediaRequest extends AbstractRequest<CreatedObjectIdResponse> {
+    /**
+     * The page id.
+     */
+    private pageId: string;
+
+    /**
+     * The constructor
+     *
+     * @param accessToken the access token.
+     * @param pageId the page id.
+     * @param imageUrl the image URL.
+     * @param caption the caption.
+     * @param locationId the location id.
+     * @param userTags the user_tags.
+     */
+    constructor(
+        accessToken: string,
+        pageId: string,
+        imageUrl: string,
+        caption?: string,
+        locationId?: string,
+        userTags?: UserTag[]
+    ) {
+        super(accessToken);
+        this.pageId = pageId;
+        this.params.image_url = imageUrl;
+        this.params.caption = caption;
+        this.params.location_id = locationId;
+        this.params.user_tags = userTags;
+    }
+
+    /**
+     * Sets the caption in the request.
+     *
+     * @param caption the caption.
+     *
+     * @returns this object, for chained invocation.
+     */
+    public withCaption(caption: string): PostPagePhotoMediaRequest {
+        this.params.caption = caption;
+        return this;
+    }
+
+    /**
+     * Sets the location id in the request.
+     *
+     * @param locationId the location id.
+     *
+     * @returns this object, for chained invocation.
+     */
+    public withLocationId(locationId: string): PostPagePhotoMediaRequest {
+        this.params.location_id = locationId;
+        return this;
+    }
+
+    /**
+     * Sets the user_tags in the request.
+     *
+     * @param userTags the user_tags.
+     *
+     * @returns this object, for chained invocation.
+     */
+    public withUserTags(userTags: UserTag[]): PostPagePhotoMediaRequest {
+        this.params.user_tags = userTags;
+        return this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected parseResponse(response: AxiosResponse<{ id: string }>): CreatedObjectIdResponse {
+        return new CreatedObjectIdResponse(response.data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected url(): string {
+        return `/${this.pageId}/media`;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected method(): Method {
+        return 'POST';
+    }
+}

--- a/src/main/requests/page/media/PostPageVideoMediaRequest.ts
+++ b/src/main/requests/page/media/PostPageVideoMediaRequest.ts
@@ -1,16 +1,15 @@
 import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { CreatedObjectIdResponse } from '../../common/CreatedObjectIdResponse';
-import { UserTag } from '../../Params';
 import { Method } from '../../RequestConfig';
 
 /**
- * A request that creates a new Photo Media container.
+ * A request that creates a new Video Media container.
  *
  * @author Tiago Grosso <tiagogrosso99@gmail.com>
  * @since `next.release`
  */
-export class PostPagePhotoMediaRequest extends AbstractRequest<CreatedObjectIdResponse> {
+export class PostPageVideoMediaRequest extends AbstractRequest<CreatedObjectIdResponse> {
     /**
      * The page id.
      */
@@ -21,25 +20,25 @@ export class PostPagePhotoMediaRequest extends AbstractRequest<CreatedObjectIdRe
      *
      * @param accessToken the access token.
      * @param pageId the page id.
-     * @param imageUrl the image URL.
+     * @param videoUrl the video URL.
      * @param caption the caption.
      * @param locationId the location id.
-     * @param userTags the user_tags.
      */
     constructor(
         accessToken: string,
         pageId: string,
-        imageUrl: string,
+        videoUrl: string,
         caption?: string,
-        locationId?: string,
-        userTags?: UserTag[]
+        thumbOffset?: number,
+        locationId?: string
     ) {
         super(accessToken);
         this.pageId = pageId;
-        this.params.image_url = imageUrl;
+        this.params.video_url = videoUrl;
         this.params.caption = caption;
+        this.params.thumb_offset = thumbOffset;
         this.params.location_id = locationId;
-        this.params.user_tags = userTags;
+        this.params.media_type = 'video';
     }
 
     /**
@@ -49,7 +48,7 @@ export class PostPagePhotoMediaRequest extends AbstractRequest<CreatedObjectIdRe
      *
      * @returns this object, for chained invocation.
      */
-    public withCaption(caption: string): PostPagePhotoMediaRequest {
+    public withCaption(caption: string): PostPageVideoMediaRequest {
         this.params.caption = caption;
         return this;
     }
@@ -61,20 +60,20 @@ export class PostPagePhotoMediaRequest extends AbstractRequest<CreatedObjectIdRe
      *
      * @returns this object, for chained invocation.
      */
-    public withLocationId(locationId: string): PostPagePhotoMediaRequest {
+    public withLocationId(locationId: string): PostPageVideoMediaRequest {
         this.params.location_id = locationId;
         return this;
     }
 
     /**
-     * Sets the user_tags in the request.
+     * Sets the thumbnail offset time in the request.
      *
-     * @param userTags the user_tags.
+     * @param thumbOffset the thumbnail offset time.
      *
      * @returns this object, for chained invocation.
      */
-    public withUserTags(userTags: UserTag[]): PostPagePhotoMediaRequest {
-        this.params.user_tags = userTags;
+    public withThumbOffset(thumbOffset: number): PostPageVideoMediaRequest {
+        this.params.thumb_offset = thumbOffset;
         return this;
     }
 

--- a/src/main/requests/page/media_publish/PostPublishMediaRequest.ts
+++ b/src/main/requests/page/media_publish/PostPublishMediaRequest.ts
@@ -1,0 +1,51 @@
+import { AxiosResponse } from 'axios';
+import { AbstractRequest } from '../../../../main/requests/AbstractRequest';
+import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
+import { Method } from '../../../../main/requests/RequestConfig';
+
+/**
+ * A request that publishes a media object.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since `next.release`
+ */
+export class PostPublishMediaRequest extends AbstractRequest<CreatedObjectIdResponse> {
+    /**
+     * The page id.
+     */
+    private pageId: string;
+
+    /**
+     * The constructor.
+     *
+     * @param accessToken the access token.
+     * @param pageId the page id.
+     * @param containerId the container id.
+     */
+    constructor(accessToken: string, pageId: string, containerId: string) {
+        super(accessToken);
+        this.pageId = pageId;
+        this.params.creation_id = containerId;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected parseResponse(response: AxiosResponse<{ id: string }>): CreatedObjectIdResponse {
+        return new CreatedObjectIdResponse(response.data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected url(): string {
+        return `/${this.pageId}/media_publish`;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected method(): Method {
+        return 'POST';
+    }
+}

--- a/src/test/Client.test.ts
+++ b/src/test/Client.test.ts
@@ -33,6 +33,7 @@ import { GetPageMonthInsightsRequest } from '../main/requests/page/insights/GetP
 import { GetPageWeekInsightsRequest } from '../main/requests/page/insights/GetPageWeekInsightsRequest';
 import { GetPageMediaRequest } from '../main/requests/page/media/GetPageMediaRequest';
 import { PostPagePhotoMediaRequest } from '../main/requests/page/media/PostPagePhotoMediaRequest';
+import { PostPageVideoMediaRequest } from '../main/requests/page/media/PostPageVideoMediaRequest';
 import { PostPublishMediaRequest } from '../main/requests/page/media_publish/PostPublishMediaRequest';
 import { GetTagsRequest } from '../main/requests/page/tags/GetTagsRequest';
 import { TestConstants } from './TestConstants';
@@ -340,12 +341,12 @@ describe('Client', () => {
     });
 
     it('Builds a PostPagePhotoMediaRequest', () => {
-        expect(client.newPostPagePhotoMediaRequest(TestConstants.IMAGE_URL)).toEqual(
-            new PostPagePhotoMediaRequest(TestConstants.ACCESS_TOKEN, TestConstants.PAGE_ID, TestConstants.IMAGE_URL)
+        expect(client.newPostPagePhotoMediaRequest(TestConstants.MEDIA_URL)).toEqual(
+            new PostPagePhotoMediaRequest(TestConstants.ACCESS_TOKEN, TestConstants.PAGE_ID, TestConstants.MEDIA_URL)
         );
         expect(
             client.newPostPagePhotoMediaRequest(
-                TestConstants.IMAGE_URL,
+                TestConstants.MEDIA_URL,
                 TestConstants.CAPTION,
                 TestConstants.LOCATION_ID,
                 [TestConstants.USER_TAG]
@@ -354,10 +355,33 @@ describe('Client', () => {
             new PostPagePhotoMediaRequest(
                 TestConstants.ACCESS_TOKEN,
                 TestConstants.PAGE_ID,
-                TestConstants.IMAGE_URL,
+                TestConstants.MEDIA_URL,
                 TestConstants.CAPTION,
                 TestConstants.LOCATION_ID,
                 [TestConstants.USER_TAG]
+            )
+        );
+    });
+
+    it('Builds a PostPageVideoMediaRequest', () => {
+        expect(client.newPostPageVideoMediaRequest(TestConstants.MEDIA_URL)).toEqual(
+            new PostPageVideoMediaRequest(TestConstants.ACCESS_TOKEN, TestConstants.PAGE_ID, TestConstants.MEDIA_URL)
+        );
+        expect(
+            client.newPostPageVideoMediaRequest(
+                TestConstants.MEDIA_URL,
+                TestConstants.CAPTION,
+                TestConstants.THUMB_OFFSET,
+                TestConstants.LOCATION_ID
+            )
+        ).toEqual(
+            new PostPageVideoMediaRequest(
+                TestConstants.ACCESS_TOKEN,
+                TestConstants.PAGE_ID,
+                TestConstants.MEDIA_URL,
+                TestConstants.CAPTION,
+                TestConstants.THUMB_OFFSET,
+                TestConstants.LOCATION_ID
             )
         );
     });

--- a/src/test/Client.test.ts
+++ b/src/test/Client.test.ts
@@ -1,6 +1,7 @@
 import { Client } from '../main/Client';
 import {
     CommentField,
+    ContainerField,
     DayMetric,
     LifetimeMetric,
     PageField,
@@ -15,6 +16,7 @@ import { GetCommentRequest } from '../main/requests/comment/GetCommentRequest';
 import { PostHideCommentRequest } from '../main/requests/comment/PostHideCommentRequest';
 import { GetRepliesRequest } from '../main/requests/comment/replies/GetRepliesRequest';
 import { PostReplyRequest } from '../main/requests/comment/replies/PostReplyRequest';
+import { GetContainerRequest } from '../main/requests/container/GetContainerRequest';
 import { GetHashtagRecentMediaRequest } from '../main/requests/hashtag/media/GetHashtagRecentMediaRequest';
 import { GetHashtagTopMediaRequest } from '../main/requests/hashtag/media/GetHashtagTopMediaRequest';
 import { GetHashtagIdRequest } from '../main/requests/hashtag/search/GetHashtagIdRequest';
@@ -30,6 +32,8 @@ import { GetPageLifetimeInsightsRequest } from '../main/requests/page/insights/G
 import { GetPageMonthInsightsRequest } from '../main/requests/page/insights/GetPageMonthInsightsRequest';
 import { GetPageWeekInsightsRequest } from '../main/requests/page/insights/GetPageWeekInsightsRequest';
 import { GetPageMediaRequest } from '../main/requests/page/media/GetPageMediaRequest';
+import { PostPagePhotoMediaRequest } from '../main/requests/page/media/PostPagePhotoMediaRequest';
+import { PostPublishMediaRequest } from '../main/requests/page/media_publish/PostPublishMediaRequest';
 import { GetTagsRequest } from '../main/requests/page/tags/GetTagsRequest';
 import { TestConstants } from './TestConstants';
 
@@ -319,6 +323,48 @@ describe('Client', () => {
                 PublicMediaField.LIKE_COUNT,
                 PublicMediaField.CAPTION
             )
+        );
+    });
+
+    it('Builds a GetContainerRquest', () => {
+        expect(client.newGetContainerRequest(TestConstants.CONTAINER_ID)).toEqual(
+            new GetContainerRequest(TestConstants.ACCESS_TOKEN, TestConstants.CONTAINER_ID)
+        );
+        expect(client.newGetContainerRequest(TestConstants.CONTAINER_ID, ...Object.values(ContainerField))).toEqual(
+            new GetContainerRequest(
+                TestConstants.ACCESS_TOKEN,
+                TestConstants.CONTAINER_ID,
+                ...Object.values(ContainerField)
+            )
+        );
+    });
+
+    it('Builds a PostPagePhotoMediaRequest', () => {
+        expect(client.newPostPagePhotoMediaRequest(TestConstants.IMAGE_URL)).toEqual(
+            new PostPagePhotoMediaRequest(TestConstants.ACCESS_TOKEN, TestConstants.PAGE_ID, TestConstants.IMAGE_URL)
+        );
+        expect(
+            client.newPostPagePhotoMediaRequest(
+                TestConstants.IMAGE_URL,
+                TestConstants.CAPTION,
+                TestConstants.LOCATION_ID,
+                [TestConstants.USER_TAG]
+            )
+        ).toEqual(
+            new PostPagePhotoMediaRequest(
+                TestConstants.ACCESS_TOKEN,
+                TestConstants.PAGE_ID,
+                TestConstants.IMAGE_URL,
+                TestConstants.CAPTION,
+                TestConstants.LOCATION_ID,
+                [TestConstants.USER_TAG]
+            )
+        );
+    });
+
+    it('Builds a PostPublishMediaRequest', () => {
+        expect(client.newPostPublishMediaRequest(TestConstants.CONTAINER_ID)).toEqual(
+            new PostPublishMediaRequest(TestConstants.ACCESS_TOKEN, TestConstants.PAGE_ID, TestConstants.CONTAINER_ID)
         );
     });
 });

--- a/src/test/TestConstants.ts
+++ b/src/test/TestConstants.ts
@@ -1,11 +1,13 @@
 import { LifetimeMetric, MetricPeriod, PageOption, WeekAndMonthMetric } from '../main/Enums';
 import { CommentData } from '../main/requests/data/CommentData';
+import { CONTAINER_STATUS_CODE } from '../main/requests/data/ContainerData';
 import { BasicInsightsMetricData, MetricValue } from '../main/requests/data/insights/BasicInsightsMetricData';
 import { ComplexMetricValue } from '../main/requests/data/insights/ComplexMetric';
 import { MeData } from '../main/requests/data/MeData';
 import { MediaData } from '../main/requests/data/MediaData';
 import { PageInfoData } from '../main/requests/data/PageInfoData';
 import { PagingData } from '../main/requests/data/Paging';
+import { UserTag } from '../main/requests/Params';
 
 /**
  * A set of constants used in tests.
@@ -364,4 +366,43 @@ export class TestConstants {
         media_type: 'CAROUSEL_ALBUM',
         permalink: 'media_permalink_2',
     };
+
+    /**
+     * A dummy image URL.
+     */
+    static readonly IMAGE_URL: string = 'https://test.com';
+
+    /**
+     * A dummy caption.
+     */
+    static readonly CAPTION: string = 'Test Caption';
+
+    /**
+     * A dummy location id.
+     */
+    static readonly LOCATION_ID: string = '111000999333';
+
+    /**
+     * A dummy user tag.
+     */
+    static readonly USER_TAG: UserTag = {
+        username: 'user',
+        x: 0.2,
+        y: 0.5,
+    };
+
+    /**
+     * A dummy container id.
+     */
+    static readonly CONTAINER_ID: string = 'container_id';
+
+    /**
+     * A dummy container status.
+     */
+    static readonly CONTAINER_STATUS: string = 'Finished: Media has been uploaded and it is ready to be published.';
+
+    /**
+     * A dummy container status code.
+     */
+    static readonly CONTAINER_STATUS_CODE: CONTAINER_STATUS_CODE = CONTAINER_STATUS_CODE.FINISHED;
 }

--- a/src/test/TestConstants.ts
+++ b/src/test/TestConstants.ts
@@ -370,7 +370,7 @@ export class TestConstants {
     /**
      * A dummy image URL.
      */
-    static readonly IMAGE_URL: string = 'https://test.com';
+    static readonly MEDIA_URL: string = 'https://test.com';
 
     /**
      * A dummy caption.
@@ -390,6 +390,11 @@ export class TestConstants {
         x: 0.2,
         y: 0.5,
     };
+
+    /**
+     * A dummy thumbnail offset time.
+     */
+    static readonly THUMB_OFFSET: number = 1000;
 
     /**
      * A dummy container id.

--- a/src/test/requests/container/GetContainerRequest.test.ts
+++ b/src/test/requests/container/GetContainerRequest.test.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { Constants } from '../../../main/Constants';
+import { ContainerField } from '../../../main/Enums';
+import { GetContainerRequest } from '../../../main/requests/container/GetContainerRequest';
+import { GetContainerResponse } from '../../../main/requests/container/GetContainerResponse';
+import { TestConstants } from '../../TestConstants';
+
+describe('GetContainerRequest', () => {
+    const request: GetContainerRequest = new GetContainerRequest(
+        TestConstants.ACCESS_TOKEN,
+        TestConstants.CONTAINER_ID,
+        ContainerField.STATUS
+    );
+    const requestAllFields: GetContainerRequest = new GetContainerRequest(
+        TestConstants.ACCESS_TOKEN,
+        TestConstants.CONTAINER_ID
+    );
+
+    it('Builds the config', () => {
+        expect(request.config().method).toEqual('GET');
+        expect(request.config().url).toEqual(`/${TestConstants.CONTAINER_ID}`);
+        expect(request.config().params.fields).toEqual(ContainerField.STATUS);
+        expect(requestAllFields.config().params.fields).toEqual(Object.values(ContainerField).join(','));
+    });
+
+    const mock = new MockAdapter(axios);
+    mock.onGet(`${Constants.API_URL}/${TestConstants.CONTAINER_ID}`).reply(200, {
+        id: TestConstants.CONTAINER_ID,
+        status: TestConstants.CONTAINER_STATUS,
+    });
+
+    it('Parses the response', () => {
+        expect.assertions(1);
+        return request.execute().then((response) => {
+            expect(response).toEqual(
+                new GetContainerResponse({ id: TestConstants.CONTAINER_ID, status: TestConstants.CONTAINER_STATUS })
+            );
+        });
+    });
+});

--- a/src/test/requests/container/GetContainerResponse.test.ts
+++ b/src/test/requests/container/GetContainerResponse.test.ts
@@ -1,0 +1,22 @@
+import { GetContainerResponse } from '../../../main/requests/container/GetContainerResponse';
+import { TestConstants } from '../../TestConstants';
+
+describe('GetContainerResponse', () => {
+    const response = new GetContainerResponse({
+        id: TestConstants.CONTAINER_ID,
+        status: TestConstants.CONTAINER_STATUS,
+        status_code: TestConstants.CONTAINER_STATUS_CODE,
+    });
+
+    it('Gets the container id', () => {
+        expect(response.getContainerId()).toEqual(TestConstants.CONTAINER_ID);
+    });
+
+    it('Gets the container status', () => {
+        expect(response.getContainerStatus()).toEqual(TestConstants.CONTAINER_STATUS);
+    });
+
+    it('Gets the container status code', () => {
+        expect(response.getContainerStatusCode()).toEqual(TestConstants.CONTAINER_STATUS_CODE);
+    });
+});

--- a/src/test/requests/page/media/PostPagePhotoMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPagePhotoMediaRequest.test.ts
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { Constants } from '../../../../main/Constants';
+import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
+import { PostPagePhotoMediaRequest } from '../../../../main/requests/page/media/PostPagePhotoMediaRequest';
+import { TestConstants } from '../../../TestConstants';
+
+describe('PostPagePhotoMediaRequest.', () => {
+    const request: PostPagePhotoMediaRequest = new PostPagePhotoMediaRequest(
+        TestConstants.ACCESS_TOKEN,
+        TestConstants.PAGE_ID,
+        TestConstants.IMAGE_URL,
+        TestConstants.CAPTION,
+        TestConstants.LOCATION_ID,
+        [TestConstants.USER_TAG]
+    );
+    const requestBare: PostPagePhotoMediaRequest = new PostPagePhotoMediaRequest(
+        TestConstants.ACCESS_TOKEN,
+        TestConstants.PAGE_ID,
+        TestConstants.IMAGE_URL
+    );
+
+    it('Builds the config', () => {
+        expect(request.config().method).toEqual('POST');
+        expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}/media`);
+        expect(request.config().params.image_url).toEqual(TestConstants.IMAGE_URL);
+        expect(request.config().params.caption).toEqual(TestConstants.CAPTION);
+        expect(request.config().params.location_id).toEqual(TestConstants.LOCATION_ID);
+        expect(request.config().params.user_tags).toEqual([TestConstants.USER_TAG]);
+    });
+
+    it('Adds params request config', () => {
+        expect(requestBare.config().params.image_url).toEqual(TestConstants.IMAGE_URL);
+        expect(requestBare.config().params.caption).toBeUndefined();
+        expect(requestBare.config().params.location_id).toBeUndefined();
+        expect(requestBare.config().params.user_tags).toBeUndefined();
+
+        requestBare.withCaption(TestConstants.CAPTION);
+        requestBare.withLocationId(TestConstants.LOCATION_ID);
+        requestBare.withUserTags([TestConstants.USER_TAG]);
+
+        expect(requestBare.config().params.caption).toEqual(TestConstants.CAPTION);
+        expect(requestBare.config().params.location_id).toEqual(TestConstants.LOCATION_ID);
+        expect(requestBare.config().params.user_tags).toEqual([TestConstants.USER_TAG]);
+    });
+
+    const mock = new MockAdapter(axios);
+    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, { id: TestConstants.CONTAINER_ID });
+    it('Parses the response', () => {
+        expect.assertions(1);
+        return request.execute().then((response) => {
+            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
+        });
+    });
+});

--- a/src/test/requests/page/media/PostPageVideoMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPageVideoMediaRequest.test.ts
@@ -2,19 +2,19 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { Constants } from '../../../../main/Constants';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
-import { PostPagePhotoMediaRequest } from '../../../../main/requests/page/media/PostPagePhotoMediaRequest';
+import { PostPageVideoMediaRequest } from '../../../../main/requests/page/media/PostPageVideoMediaRequest';
 import { TestConstants } from '../../../TestConstants';
 
-describe('PostPagePhotoMediaRequest.', () => {
-    const request: PostPagePhotoMediaRequest = new PostPagePhotoMediaRequest(
+describe('PostPageVideoMediaRequest.', () => {
+    const request: PostPageVideoMediaRequest = new PostPageVideoMediaRequest(
         TestConstants.ACCESS_TOKEN,
         TestConstants.PAGE_ID,
         TestConstants.MEDIA_URL,
         TestConstants.CAPTION,
-        TestConstants.LOCATION_ID,
-        [TestConstants.USER_TAG]
+        TestConstants.THUMB_OFFSET,
+        TestConstants.LOCATION_ID
     );
-    const requestBare: PostPagePhotoMediaRequest = new PostPagePhotoMediaRequest(
+    const requestBare: PostPageVideoMediaRequest = new PostPageVideoMediaRequest(
         TestConstants.ACCESS_TOKEN,
         TestConstants.PAGE_ID,
         TestConstants.MEDIA_URL
@@ -23,25 +23,25 @@ describe('PostPagePhotoMediaRequest.', () => {
     it('Builds the config', () => {
         expect(request.config().method).toEqual('POST');
         expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}/media`);
-        expect(request.config().params.image_url).toEqual(TestConstants.MEDIA_URL);
+        expect(request.config().params.video_url).toEqual(TestConstants.MEDIA_URL);
         expect(request.config().params.caption).toEqual(TestConstants.CAPTION);
+        expect(request.config().params.thumb_offset).toEqual(TestConstants.THUMB_OFFSET);
         expect(request.config().params.location_id).toEqual(TestConstants.LOCATION_ID);
-        expect(request.config().params.user_tags).toEqual([TestConstants.USER_TAG]);
     });
 
     it('Adds params request config', () => {
-        expect(requestBare.config().params.image_url).toEqual(TestConstants.MEDIA_URL);
+        expect(requestBare.config().params.video_url).toEqual(TestConstants.MEDIA_URL);
         expect(requestBare.config().params.caption).toBeUndefined();
         expect(requestBare.config().params.location_id).toBeUndefined();
-        expect(requestBare.config().params.user_tags).toBeUndefined();
+        expect(requestBare.config().params.thumb_offset).toBeUndefined();
 
         requestBare.withCaption(TestConstants.CAPTION);
         requestBare.withLocationId(TestConstants.LOCATION_ID);
-        requestBare.withUserTags([TestConstants.USER_TAG]);
+        requestBare.withThumbOffset(TestConstants.THUMB_OFFSET);
 
         expect(requestBare.config().params.caption).toEqual(TestConstants.CAPTION);
+        expect(requestBare.config().params.thumb_offset).toEqual(TestConstants.THUMB_OFFSET);
         expect(requestBare.config().params.location_id).toEqual(TestConstants.LOCATION_ID);
-        expect(requestBare.config().params.user_tags).toEqual([TestConstants.USER_TAG]);
     });
 
     const mock = new MockAdapter(axios);

--- a/src/test/requests/page/media_publish/PostPublishMediaRequest.test.ts
+++ b/src/test/requests/page/media_publish/PostPublishMediaRequest.test.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { Constants } from '../../../../main/Constants';
+import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
+import { PostPublishMediaRequest } from '../../../../main/requests/page/media_publish/PostPublishMediaRequest';
+import { TestConstants } from '../../../TestConstants';
+
+describe('PostPublishMediaRequest', () => {
+    const request: PostPublishMediaRequest = new PostPublishMediaRequest(
+        TestConstants.ACCESS_TOKEN,
+        TestConstants.PAGE_ID,
+        TestConstants.CONTAINER_ID
+    );
+
+    it('Builds the config', () => {
+        expect(request.config().method).toEqual('POST');
+        expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}/media_publish`);
+        expect(request.config().params.creation_id).toEqual(TestConstants.CONTAINER_ID);
+    });
+
+    const mock = new MockAdapter(axios);
+    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media_publish`).reply(200, {
+        id: TestConstants.MEDIA_ID,
+    });
+    it('Parses the response', () => {
+        expect.assertions(1);
+        return request.execute().then((response) => {
+            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.MEDIA_ID }));
+        });
+    });
+});


### PR DESCRIPTION
-   `PostPagePhotoMediaRequest` and `PostPageVideoMediaRequest` to create media containers.
-   `PostPublishMediaRequest` to publish the containers created through the previous requests.
-   `GetContainerRequest` to get the status of a created container.