### PR TITLE
Upgrade to API v13.0

### DIFF
--- a/src/main/Client.ts
+++ b/src/main/Client.ts
@@ -4,6 +4,7 @@ import {
     ContainerField,
     ContentPublishingLimitFields,
     DayMetric,
+    HashtagMediaField,
     LifetimeMetric,
     MediaField,
     PageField,
@@ -267,7 +268,7 @@ export class Client {
     public newGetHashtagRecentMediaRequest(
         hashtagId: string,
         userId: string = this.pageId,
-        ...fields: PublicMediaField[]
+        ...fields: HashtagMediaField[]
     ): GetHashtagRecentMediaRequest {
         return new GetHashtagRecentMediaRequest(this.accessToken, hashtagId, userId, ...fields).withApiVersion(
             this.apiVersion
@@ -286,7 +287,7 @@ export class Client {
     public newGetHashtagTopMediaRequest(
         hashtagId: string,
         userId: string = this.pageId,
-        ...fields: PublicMediaField[]
+        ...fields: HashtagMediaField[]
     ): GetHashtagTopMediaRequest {
         return new GetHashtagTopMediaRequest(this.accessToken, hashtagId, userId, ...fields).withApiVersion(
             this.apiVersion

--- a/src/main/Enums.ts
+++ b/src/main/Enums.ts
@@ -269,7 +269,60 @@ export enum PrivateMediaField {
     THUMBNAIL_URL = 'thumbnail_url',
 }
 
-export type MediaField = PrivateMediaField | PublicMediaField;
+/**
+ * Hashtag Media info fields.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since `next.release`
+ */
+export enum HashtagMediaField {
+    /**
+     * The caption of the media.
+     */
+    CAPTION = 'caption',
+
+    /**
+     * The number of comments on the media object.
+     */
+    COMMENTS_COUNT = 'comments_count',
+
+    /**
+     * The id of the media object.
+     */
+    ID = 'id',
+
+    /**
+     * The children of the media object. Only returned for Album IG Media.
+     */
+    CHILDREN = 'children',
+
+    /**
+     * The number of likes on the media object.
+     */
+    LIKE_COUNT = 'like_count',
+
+    /**
+     * The type of media object.
+     */
+    MEDIA_TYPE = 'media_type',
+
+    /**
+     * The URL of the media object.
+     */
+    MEDIA_URL = 'media_url',
+
+    /**
+     * The permalink of the media object.
+     */
+    PERMALINK = 'permalink',
+
+    /**
+     * The ISO 8601 formatted creation date in UTC (default is UTC ±00:00)
+     */
+    TIMESTAMP = 'timestamp',
+}
+
+export type MediaField = PrivateMediaField | PublicMediaField | HashtagMediaField;
 
 /**
  * The surfaces where media can bne published.
@@ -514,4 +567,16 @@ export enum ApiVersion {
      * {@link https://developers.facebook.com/docs/graph-api/changelog/version11.0}
      */
     V11_0 = 'v11.0',
+
+    /**
+     * {@link https://developers.facebook.com/docs/graph-api/changelog/version12.0}
+     */
+    V12_0 = 'v12.0',
+
+    /**
+     * {@link https://developers.facebook.com/docs/graph-api/changelog/version13.0}
+     */
+    V13_0 = 'v13.0',
+
+    LATEST = V13_0,
 }

--- a/src/main/Utils.ts
+++ b/src/main/Utils.ts
@@ -13,6 +13,9 @@ export class Utils {
      * @returns an array with all the media fields.
      */
     public static getAllMediaFields(): MediaField[] {
-        return [...Object.values(PublicMediaField), ...Object.values(PrivateMediaField)];
+        return [
+            ...Object.values(PublicMediaField).filter((field) => field != PublicMediaField.VIDEO_TITLE), //Filter out the video title because it's deprecated
+            ...Object.values(PrivateMediaField),
+        ];
     }
 }

--- a/src/main/requests/hashtag/media/AbstractGetHashtagMediaRequest.ts
+++ b/src/main/requests/hashtag/media/AbstractGetHashtagMediaRequest.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from 'axios';
-import { PublicMediaField } from '../../../Enums';
+import { HashtagMediaField } from '../../../Enums';
 import { AbstractGetMediaRequest } from '../../AbstractGetMediaRequest';
 import { GetHashtagMediaResponse } from './GetHashtagMediaResponse';
 
@@ -23,8 +23,8 @@ export abstract class AbstractGetHashtagMediaRequest extends AbstractGetMediaReq
      * @param userId the id of the user making the request.
      * @param fields the fields to retrieve from the API. If no field is specified, all are retrieved.
      */
-    constructor(accessToken: string, hashtagId: string, userId: string, ...fields: PublicMediaField[]) {
-        const actualFields: PublicMediaField[] = fields.length > 0 ? fields : Object.values(PublicMediaField);
+    constructor(accessToken: string, hashtagId: string, userId: string, ...fields: HashtagMediaField[]) {
+        const actualFields: HashtagMediaField[] = fields.length > 0 ? fields : Object.values(HashtagMediaField);
         super(accessToken, ...actualFields);
         this.hashtagId = hashtagId;
         this.params.user_id = userId;

--- a/src/main/requests/media/info/GetMediaInfoRequest.ts
+++ b/src/main/requests/media/info/GetMediaInfoRequest.ts
@@ -23,7 +23,10 @@ export class GetMediaInfoRequest extends AbstractGetMediaRequest<GetMediaInfoRes
      * @param fields the fields to retrieve from the API for each media object. If no field is specified, all public fields are retrieved.
      */
     constructor(accessToken: string, mediaId: string, ...fields: MediaField[]) {
-        const actualFields: MediaField[] = fields.length > 0 ? fields : Object.values(PublicMediaField);
+        const actualFields: MediaField[] =
+            fields.length > 0
+                ? fields
+                : Object.values(PublicMediaField).filter((field) => field != PublicMediaField.VIDEO_TITLE); //Filter out the video title because it's deprecated
         super(accessToken, ...actualFields);
         this.mediaId = mediaId;
     }

--- a/src/main/requests/page/tags/GetTagsRequest.ts
+++ b/src/main/requests/page/tags/GetTagsRequest.ts
@@ -23,7 +23,11 @@ export class GetTagsRequest extends AbstractGetMediaRequest<GetTagsResponse> {
      * @param fields the fields to retrieve from the API for each media object. If no field is specified, all public fields are retrieved.
      */
     constructor(accessToken: string, pageId: string, ...fields: MediaField[]) {
-        const actualFields: MediaField[] = fields.length > 0 ? fields : Object.values(PublicMediaField);
+        const actualFields: MediaField[] =
+            fields.length > 0
+                ? fields
+                : Object.values(PublicMediaField).filter((field) => field != PublicMediaField.VIDEO_TITLE); //Filter out the video title because it's deprecated
+
         super(accessToken, ...actualFields);
         this.pageId = pageId;
     }

--- a/src/main/requests/page/tags/GetTagsResponse.ts
+++ b/src/main/requests/page/tags/GetTagsResponse.ts
@@ -21,7 +21,7 @@ export class GetTagsResponse extends AbstractGetManyMediaResponse {
      */
     constructor(body: { data: MediaData[]; paging: PagingData }) {
         super(body.data);
-        this.cursors = body.paging.cursors;
+        this.cursors = body.paging?.cursors;
     }
 
     /**

--- a/src/test/Client.test.ts
+++ b/src/test/Client.test.ts
@@ -4,6 +4,7 @@ import {
     ContainerField,
     ContentPublishingLimitFields,
     DayMetric,
+    HashtagMediaField,
     LifetimeMetric,
     PageField,
     PrivateMediaField,
@@ -307,16 +308,16 @@ describe('Client', () => {
             client.newGetHashtagRecentMediaRequest(
                 TestConstants.HASHTAG_ID,
                 TestConstants.PAGE_ID_2,
-                PublicMediaField.CAPTION,
-                PublicMediaField.CHILDREN
+                HashtagMediaField.CAPTION,
+                HashtagMediaField.CHILDREN
             )
         ).toEqual(
             new GetHashtagRecentMediaRequest(
                 TestConstants.ACCESS_TOKEN,
                 TestConstants.HASHTAG_ID,
                 TestConstants.PAGE_ID_2,
-                PublicMediaField.CAPTION,
-                PublicMediaField.CHILDREN
+                HashtagMediaField.CAPTION,
+                HashtagMediaField.CHILDREN
             )
         );
     });
@@ -336,16 +337,16 @@ describe('Client', () => {
             client.newGetHashtagTopMediaRequest(
                 TestConstants.HASHTAG_ID,
                 TestConstants.PAGE_ID_2,
-                PublicMediaField.CAPTION,
-                PublicMediaField.CHILDREN
+                HashtagMediaField.CAPTION,
+                HashtagMediaField.CHILDREN
             )
         ).toEqual(
             new GetHashtagTopMediaRequest(
                 TestConstants.ACCESS_TOKEN,
                 TestConstants.HASHTAG_ID,
                 TestConstants.PAGE_ID_2,
-                PublicMediaField.CAPTION,
-                PublicMediaField.CHILDREN
+                HashtagMediaField.CAPTION,
+                HashtagMediaField.CHILDREN
             )
         );
     });

--- a/src/test/requests/hashtag/media/AbstractGetHashtagMediaRequest.test.ts
+++ b/src/test/requests/hashtag/media/AbstractGetHashtagMediaRequest.test.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { Constants } from '../../../../main/Constants';
-import { PublicMediaField } from '../../../../main/Enums';
+import { HashtagMediaField } from '../../../../main/Enums';
 import { AbstractGetHashtagMediaRequest } from '../../../../main/requests/hashtag/media/AbstractGetHashtagMediaRequest';
 import { GetPageMediaResponse } from '../../../../main/requests/page/media/GetPageMediaResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -13,8 +13,8 @@ describe('AbstractGetHashtagMediaRequest', () => {
         TestConstants.ACCESS_TOKEN,
         TestConstants.HASHTAG_ID,
         TestConstants.PAGE_ID,
-        PublicMediaField.CAPTION,
-        PublicMediaField.CHILDREN
+        HashtagMediaField.CAPTION,
+        HashtagMediaField.CHILDREN
     );
     const requestAllFields: AbstractGetHashtagMediaRequestImpl = new AbstractGetHashtagMediaRequestImpl(
         TestConstants.ACCESS_TOKEN,
@@ -23,13 +23,13 @@ describe('AbstractGetHashtagMediaRequest', () => {
     );
 
     it('Builds the config', () => {
-        const fields = `${PublicMediaField.CAPTION},${PublicMediaField.CHILDREN}`;
+        const fields = `${HashtagMediaField.CAPTION},${HashtagMediaField.CHILDREN}`;
 
         expect(request.config().params.fields).toEqual(fields);
         expect(request.config().params.user_id).toEqual(TestConstants.PAGE_ID);
         expect(request.config().method).toEqual('GET');
         expect(request.config().url).toEqual(`/${TestConstants.HASHTAG_ID}`);
-        expect(requestAllFields.config().params.fields).toEqual(Object.values(PublicMediaField).join(','));
+        expect(requestAllFields.config().params.fields).toEqual(Object.values(HashtagMediaField).join(','));
     });
 
     const mock = new MockAdapter(axios);

--- a/src/test/requests/media/info/GetMediaInfoRequest.test.ts
+++ b/src/test/requests/media/info/GetMediaInfoRequest.test.ts
@@ -24,7 +24,11 @@ describe('GetMediaInfoRequest', () => {
         expect(request.config().params.fields).toEqual(fields);
         expect(request.config().method).toEqual('GET');
         expect(request.config().url).toEqual(`/${TestConstants.MEDIA_ID}`);
-        expect(requestAllFields.config().params.fields).toEqual(Object.values(PublicMediaField).join(','));
+        expect(requestAllFields.config().params.fields).toEqual(
+            Object.values(PublicMediaField)
+                .filter((field) => field != PublicMediaField.VIDEO_TITLE)
+                .join(',')
+        );
     });
 
     const mock = new MockAdapter(axios);

--- a/src/test/requests/page/tags/GetTagsRequest.test.ts
+++ b/src/test/requests/page/tags/GetTagsRequest.test.ts
@@ -22,7 +22,11 @@ describe('GetTagsRequest', () => {
         expect(request.config().method).toEqual('GET');
         expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}/tags`);
 
-        expect(requestAllFields.config().params.fields).toEqual(Object.values(PublicMediaField).join(','));
+        expect(requestAllFields.config().params.fields).toEqual(
+            Object.values(PublicMediaField)
+                .filter((field) => field != PublicMediaField.VIDEO_TITLE)
+                .join(',')
+        );
     });
 
     const mock = new MockAdapter(axios);


### PR DESCRIPTION
- Adds v12 and v13 as ApiVersion options
- Removes deleted fields in Hashtag media requests
- Deprecated video_title field in media requests