### PR TITLE
feat(page): adds requests to publish stories to page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This package is made by independent contributors and is in no way officially rel
 
 You can find what changed in each version by checking the [Changelog](changelog/changelog.md).
 
-## New since 5.0
+## New since 6.1
 
-You can now use this lib to publish reels to your page! Check out the [Publishing media](#publishing-media) section.
+You can now use this lib to publish stories to your page! Check out the [Publishing media](#publishing-media) section.
 
 ## Installation
 
@@ -94,9 +94,11 @@ Publishing Media through the Instagram Graph API, and conversely through this li
 
 1. Create an IG Container object. The request will return the container id.
    - For photos use `PostPagePhotoMediaRequest`.
-   - For videos use `PostPageVideoMediaRequest`.
+   - ~~For videos use `PostPageVideoMediaRequest`.~~ Instagram has removed the ability to publish normal/legacy videos through their API. Videos are now always reels.
    - For reels use `PostPageReelMediaRequest`.
    - For carousels check the [Publishing Carousels section below](#publishing-carousels).
+   - For Story videos use `PostPageStoryPhotoMediaRequest`
+   - For Story videos use `PostPageStoryVideoMediaRequest`
 2. Wait for the IG Container status to move to `FINISHED` (check the status through the `GetContainerRequest`).
 3. Publish the IG Container (through the `PostPublishMediaRequest`).
 
@@ -222,4 +224,4 @@ request.execute().then((response: GetAuthorizedFacebookPagesResponse) => {
 
 ## Release Process
 
-Releases of this lib should be very incremental. When a new resource is supported a release will be issued soon after without waiting to pile up new features to do big releases.
+This project follows [Semantic Release](https://github.com/semantic-release/) with a publish on every commit to `master`.

--- a/src/it/page/PublishMediaRequests.test.ts
+++ b/src/it/page/PublishMediaRequests.test.ts
@@ -61,6 +61,38 @@ describe('PublishMedia', () => {
         expect(response.getMediaType()).toEqual(MediaTypeInResponses.VIDEO);
         expect(response.getMediaProductType()).toEqual(MediaProductType.REEL);
     });
+
+    it('Publishes story image media', async () => {
+        const media = getRandomPhoto();
+        const postStoryRequest = getClient().newPostPageStoriesPhotoMediaRequest(media.url);
+
+        const containerId = await createContainerAndWaitToBeReady(postStoryRequest);
+
+        const mediaId = await publishMedia(containerId);
+        const getMediaRequest = getClient().newGetMediaInfoRequest(mediaId);
+        const response = await getMediaRequest.execute();
+
+        expect(response.getId()).toEqual(mediaId);
+        expect(response.getOwnerId()).toEqual(getPageId());
+        expect(response.getMediaType()).toEqual(MediaTypeInResponses.IMAGE);
+        expect(response.getMediaProductType()).toEqual(MediaProductType.STORY);
+    });
+
+    it('Publishes story video media', async () => {
+        const media = getRandomVideo();
+        const postStoryRequest = getClient().newPostPageStoriesVideoMediaRequest(media.url);
+
+        const containerId = await createContainerAndWaitToBeReady(postStoryRequest);
+
+        const mediaId = await publishMedia(containerId);
+        const getMediaRequest = getClient().newGetMediaInfoRequest(mediaId);
+        const response = await getMediaRequest.execute();
+
+        expect(response.getId()).toEqual(mediaId);
+        expect(response.getOwnerId()).toEqual(getPageId());
+        expect(response.getMediaType()).toEqual(MediaTypeInResponses.VIDEO);
+        expect(response.getMediaProductType()).toEqual(MediaProductType.STORY);
+    });
 });
 
 function waitForContainerToBeReady(containerId: string): Promise<boolean> {

--- a/src/main/Client.ts
+++ b/src/main/Client.ts
@@ -44,6 +44,8 @@ import { GetPageStoriesRequest } from './requests/page/stories/GetPageStoriesReq
 import { GetTagsRequest } from './requests/page/tags/GetTagsRequest';
 import { UserTag } from './requests/Params';
 import { PostPageReelMediaRequest } from './requests/page/media/PostPageReelMediaRequest';
+import { PostPageStoriesPhotoMediaRequest } from './requests/page/media/PostPageStoriesPhotoMediaRequest';
+import { PostPageStoriesVideoMediaRequest } from './requests/page/media/PostPageStoriesVideoMediaRequest';
 
 /**
  * A client that creating requests.
@@ -454,6 +456,32 @@ export class Client {
             caption,
             locationId
         ).withApiVersion(this.apiVersion);
+    }
+
+    /**
+     * Build a new {@link PostPageStoriesPhotoMediaRequest}.
+     *
+     * @param imageUrl the image URL.
+     *
+     * @returns a new {@link PostPageStoriesPhotoMediaRequest}.
+     */
+    public newPostPageStoriesPhotoMediaRequest(imageUrl: string): PostPageStoriesPhotoMediaRequest {
+        return new PostPageStoriesPhotoMediaRequest(this.accessToken, this.pageId, imageUrl).withApiVersion(
+            this.apiVersion
+        );
+    }
+
+    /**
+     * Build a new {@link PostPageStoriesVideoMediaRequest}.
+     *
+     * @param videoUrl the video URL.
+     *
+     * @returns a new {@link PostPageStoriesVideoMediaRequest}.
+     */
+    public newPostPageStoriesVideoMediaRequest(videoUrl: string): PostPageStoriesVideoMediaRequest {
+        return new PostPageStoriesVideoMediaRequest(this.accessToken, this.pageId, videoUrl).withApiVersion(
+            this.apiVersion
+        );
     }
 
     /**

--- a/src/main/requests/page/media/AbstractPostPageMediaRequest.ts
+++ b/src/main/requests/page/media/AbstractPostPageMediaRequest.ts
@@ -20,39 +20,11 @@ export abstract class AbstractPostPageMediaRequest extends AbstractRequest<Creat
      *
      * @param accessToken the access token.
      * @param pageId the page id.
-     * @param caption the caption.
-     * @param locationId the location id.
      */
-    protected constructor(accessToken: string, pageId: string, caption?: string, locationId?: string) {
+    protected constructor(accessToken: string, pageId: string) {
         super(accessToken);
         this.pageId = pageId;
-        this.params.caption = caption;
-        this.params.location_id = locationId;
         this.params.media_type = this.mediaType();
-    }
-
-    /**
-     * Sets the caption in the request.
-     *
-     * @param caption the caption.
-     *
-     * @returns this object, for chained invocation.
-     */
-    public withCaption(caption: string): this {
-        this.params.caption = caption;
-        return this;
-    }
-
-    /**
-     * Sets the location id in the request.
-     *
-     * @param locationId the location id.
-     *
-     * @returns this object, for chained invocation.
-     */
-    public withLocationId(locationId: string): this {
-        this.params.location_id = locationId;
-        return this;
     }
 
     /**
@@ -96,4 +68,6 @@ export enum MediaType {
     CAROUSEL = 'CAROUSEL',
 
     REEL = 'REELS',
+
+    STORIES = 'STORIES',
 }

--- a/src/main/requests/page/media/AbstractPostPageStoriesMediaRequest.ts
+++ b/src/main/requests/page/media/AbstractPostPageStoriesMediaRequest.ts
@@ -1,0 +1,29 @@
+import { AbstractPostPageMediaRequest, MediaType } from './AbstractPostPageMediaRequest';
+
+/**
+ * An abstract request that creates a new Media container for media that goes to stories.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ */
+export abstract class AbstractPostPageStoriesMediaRequest extends AbstractPostPageMediaRequest {
+    /**
+     * The constructor
+     *
+     * @param accessToken the access token.
+     * @param pageId the page id.
+     * @param caption the caption.
+     * @param locationId the location id.
+     */
+    protected constructor(accessToken: string, pageId: string) {
+        super(accessToken, pageId);
+    }
+
+    /**
+     * Gets the media type of the object to create.
+     *
+     * @returns the media type.
+     */
+    protected mediaType(): MediaType | undefined {
+        return MediaType.STORIES;
+    }
+}

--- a/src/main/requests/page/media/AbstractPostTimelineMediaRequest.ts
+++ b/src/main/requests/page/media/AbstractPostTimelineMediaRequest.ts
@@ -1,0 +1,54 @@
+import { AbstractPostPageMediaRequest, MediaType } from './AbstractPostPageMediaRequest';
+
+/**
+ * An abstract request that creates a new Media container for media that goes to the timeline.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ * @since 3.0.0
+ */
+export abstract class AbstractPostPageTimelineMediaRequest extends AbstractPostPageMediaRequest {
+    /**
+     * The constructor
+     *
+     * @param accessToken the access token.
+     * @param pageId the page id.
+     * @param caption the caption.
+     * @param locationId the location id.
+     */
+    protected constructor(accessToken: string, pageId: string, caption?: string, locationId?: string) {
+        super(accessToken, pageId);
+        this.params.caption = caption;
+        this.params.location_id = locationId;
+    }
+
+    /**
+     * Sets the caption in the request.
+     *
+     * @param caption the caption.
+     *
+     * @returns this object, for chained invocation.
+     */
+    public withCaption(caption: string): this {
+        this.params.caption = caption;
+        return this;
+    }
+
+    /**
+     * Sets the location id in the request.
+     *
+     * @param locationId the location id.
+     *
+     * @returns this object, for chained invocation.
+     */
+    public withLocationId(locationId: string): this {
+        this.params.location_id = locationId;
+        return this;
+    }
+
+    /**
+     * Gets the media type of the object to create.
+     *
+     * @returns the media type.
+     */
+    protected abstract mediaType(): MediaType | undefined;
+}

--- a/src/main/requests/page/media/PostPageCarouselMediaRequest.ts
+++ b/src/main/requests/page/media/PostPageCarouselMediaRequest.ts
@@ -1,4 +1,5 @@
-import { AbstractPostPageMediaRequest, MediaType } from './AbstractPostPageMediaRequest';
+import { MediaType } from './AbstractPostPageMediaRequest';
+import { AbstractPostPageTimelineMediaRequest } from './AbstractPostTimelineMediaRequest';
 
 /**
  * A request that creates a new Carousel Media container.
@@ -6,7 +7,7 @@ import { AbstractPostPageMediaRequest, MediaType } from './AbstractPostPageMedia
  * @author Tiago Grosso <tiagogrosso99@gmail.com>
  * @since 3.0.0
  */
-export class PostPageCarouselMediaRequest extends AbstractPostPageMediaRequest {
+export class PostPageCarouselMediaRequest extends AbstractPostPageTimelineMediaRequest {
     /**
      * The constructor
      *

--- a/src/main/requests/page/media/PostPagePhotoMediaRequest.ts
+++ b/src/main/requests/page/media/PostPagePhotoMediaRequest.ts
@@ -1,5 +1,6 @@
 import { UserTag } from '../../Params';
-import { AbstractPostPageMediaRequest, MediaType } from './AbstractPostPageMediaRequest';
+import { MediaType } from './AbstractPostPageMediaRequest';
+import { AbstractPostPageTimelineMediaRequest } from './AbstractPostTimelineMediaRequest';
 
 /**
  * A request that creates a new Photo Media container.
@@ -7,7 +8,7 @@ import { AbstractPostPageMediaRequest, MediaType } from './AbstractPostPageMedia
  * @author Tiago Grosso <tiagogrosso99@gmail.com>
  * @since 1.1.0
  */
-export class PostPagePhotoMediaRequest extends AbstractPostPageMediaRequest {
+export class PostPagePhotoMediaRequest extends AbstractPostPageTimelineMediaRequest {
     /**
      * The constructor
      *

--- a/src/main/requests/page/media/PostPageReelMediaRequest.ts
+++ b/src/main/requests/page/media/PostPageReelMediaRequest.ts
@@ -1,4 +1,5 @@
-import { AbstractPostPageMediaRequest, MediaType } from './AbstractPostPageMediaRequest';
+import { MediaType } from './AbstractPostPageMediaRequest';
+import { AbstractPostPageTimelineMediaRequest } from './AbstractPostTimelineMediaRequest';
 
 /**
  * * A request that creates a new Reels Media container.
@@ -6,7 +7,7 @@ import { AbstractPostPageMediaRequest, MediaType } from './AbstractPostPageMedia
  *  * @author Tiago Grosso <tiagogrosso99@gmail.com>
  *  * @since 5.0.0
  *  */
-export class PostPageReelMediaRequest extends AbstractPostPageMediaRequest {
+export class PostPageReelMediaRequest extends AbstractPostPageTimelineMediaRequest {
     /**
      * The constructor
      *

--- a/src/main/requests/page/media/PostPageStoriesPhotoMediaRequest.ts
+++ b/src/main/requests/page/media/PostPageStoriesPhotoMediaRequest.ts
@@ -1,0 +1,13 @@
+import { AbstractPostPageStoriesMediaRequest } from './AbstractPostPageStoriesMediaRequest';
+
+/**
+ * A request that creates a new photo media container for stories.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ */
+export class PostPageStoriesPhotoMediaRequest extends AbstractPostPageStoriesMediaRequest {
+    constructor(accessToken: string, pageId: string, imageUrl: string) {
+        super(accessToken, pageId);
+        this.params.image_url = imageUrl;
+    }
+}

--- a/src/main/requests/page/media/PostPageStoriesVideoMediaRequest.ts
+++ b/src/main/requests/page/media/PostPageStoriesVideoMediaRequest.ts
@@ -1,0 +1,13 @@
+import { AbstractPostPageStoriesMediaRequest } from './AbstractPostPageStoriesMediaRequest';
+
+/**
+ * A request that creates a new video media container for stories.
+ *
+ * @author Tiago Grosso <tiagogrosso99@gmail.com>
+ */
+export class PostPageStoriesVideoMediaRequest extends AbstractPostPageStoriesMediaRequest {
+    constructor(accessToken: string, pageId: string, videoUrl: string) {
+        super(accessToken, pageId);
+        this.params.video_url = videoUrl;
+    }
+}

--- a/src/test/Client.test.ts
+++ b/src/test/Client.test.ts
@@ -39,6 +39,8 @@ import { GetPageMediaRequest } from '../main/requests/page/media/GetPageMediaReq
 import { PostPageCarouselMediaRequest } from '../main/requests/page/media/PostPageCarouselMediaRequest';
 import { PostPagePhotoMediaRequest } from '../main/requests/page/media/PostPagePhotoMediaRequest';
 import { PostPageReelMediaRequest } from '../main/requests/page/media/PostPageReelMediaRequest';
+import { PostPageStoriesPhotoMediaRequest } from '../main/requests/page/media/PostPageStoriesPhotoMediaRequest';
+import { PostPageStoriesVideoMediaRequest } from '../main/requests/page/media/PostPageStoriesVideoMediaRequest';
 import { PostPublishMediaRequest } from '../main/requests/page/media_publish/PostPublishMediaRequest';
 import { GetPageRecentlySearchedHashtagsRequest } from '../main/requests/page/recently_searched_hashtags/GetPageRecentlySearchedHashtagsRequest';
 import { GetPageStoriesRequest } from '../main/requests/page/stories/GetPageStoriesRequest';
@@ -564,6 +566,40 @@ describe('Client', () => {
                 TestConstants.ACCESS_TOKEN,
                 TestConstants.PAGE_ID,
                 TestConstants.CONTAINER_ID
+            ).withApiVersion(TestConstants.API_VERSION)
+        );
+    });
+
+    it('Builds a PostPageStoriesPhotoMediaRequest', () => {
+        expect(client.newPostPageStoriesPhotoMediaRequest(TestConstants.MEDIA_URL)).toEqual(
+            new PostPageStoriesPhotoMediaRequest(
+                TestConstants.ACCESS_TOKEN,
+                TestConstants.PAGE_ID,
+                TestConstants.MEDIA_URL
+            )
+        );
+        expect(clientExplicitVersion.newPostPageStoriesPhotoMediaRequest(TestConstants.MEDIA_URL)).toEqual(
+            new PostPageStoriesPhotoMediaRequest(
+                TestConstants.ACCESS_TOKEN,
+                TestConstants.PAGE_ID,
+                TestConstants.MEDIA_URL
+            ).withApiVersion(TestConstants.API_VERSION)
+        );
+    });
+
+    it('Builds a PostPageStoriesVideoMediaRequest', () => {
+        expect(client.newPostPageStoriesVideoMediaRequest(TestConstants.MEDIA_URL)).toEqual(
+            new PostPageStoriesVideoMediaRequest(
+                TestConstants.ACCESS_TOKEN,
+                TestConstants.PAGE_ID,
+                TestConstants.MEDIA_URL
+            )
+        );
+        expect(clientExplicitVersion.newPostPageStoriesVideoMediaRequest(TestConstants.MEDIA_URL)).toEqual(
+            new PostPageStoriesVideoMediaRequest(
+                TestConstants.ACCESS_TOKEN,
+                TestConstants.PAGE_ID,
+                TestConstants.MEDIA_URL
             ).withApiVersion(TestConstants.API_VERSION)
         );
     });

--- a/src/test/requests/page/media/PostPageStoriesPhotoMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPageStoriesPhotoMediaRequest.test.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { Constants } from '../../../../main/Constants';
+import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
+import { TestConstants } from '../../../TestConstants';
+import { PostPageStoriesVideoMediaRequest } from '../../../../main/requests/page/media/PostPageStoriesVideoMediaRequest';
+
+describe('PostPageStoriesVideoMediaRequest.', () => {
+    const request: PostPageStoriesVideoMediaRequest = new PostPageStoriesVideoMediaRequest(
+        TestConstants.ACCESS_TOKEN,
+        TestConstants.PAGE_ID,
+        TestConstants.MEDIA_URL
+    );
+
+    it('Builds the config', () => {
+        expect(request.config().method).toEqual('POST');
+        expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}/media`);
+        expect(request.config().params.video_url).toEqual(TestConstants.MEDIA_URL);
+    });
+
+    const mock = new MockAdapter(axios);
+    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, { id: TestConstants.CONTAINER_ID });
+    it('Parses the response', () => {
+        expect.assertions(1);
+        return request.execute().then((response) => {
+            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
+        });
+    });
+});

--- a/src/test/requests/page/media/PostPageStoriesVideoMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPageStoriesVideoMediaRequest.test.ts
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { Constants } from '../../../../main/Constants';
+import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
+import { PostPageStoriesPhotoMediaRequest } from '../../../../main/requests/page/media/PostPageStoriesPhotoMediaRequest';
+import { TestConstants } from '../../../TestConstants';
+
+describe('PostPageStoriesPhotoMediaRequest.', () => {
+    const request: PostPageStoriesPhotoMediaRequest = new PostPageStoriesPhotoMediaRequest(
+        TestConstants.ACCESS_TOKEN,
+        TestConstants.PAGE_ID,
+        TestConstants.MEDIA_URL
+    );
+
+    it('Builds the config', () => {
+        expect(request.config().method).toEqual('POST');
+        expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}/media`);
+        expect(request.config().params.image_url).toEqual(TestConstants.MEDIA_URL);
+    });
+
+    const mock = new MockAdapter(axios);
+    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, { id: TestConstants.CONTAINER_ID });
+    it('Parses the response', () => {
+        expect.assertions(1);
+        return request.execute().then((response) => {
+            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
+        });
+    });
+});


### PR DESCRIPTION
Adds `PostPageStoriesVideoMediaRequest` and `PostPageStoriesStoriesMediaRequest` (and associated factory methods in the client) to allow publishing stories to the page

Publishing stories follows the same flow as other media object: create the container -> wait for it to be ready -> publish container