### PR TITLE
feat(request): remove axios and use native fetch instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ This package is made by independent contributors and is in no way officially rel
 
 You can find what changed in each version by checking the [Changelog](changelog/changelog.md).
 
-## New since 6.1
+## New since 7.0
 
-You can now use this lib to publish stories to your page! Check out the [Publishing media](#publishing-media) section.
+This lib is now dependency free 🎉
+
+Axios has been removed as a dependency. `execute()` and `config()` methods still work exactly the same on the outside.
+
+Error handling using `AxiosError` is essentially the major change.
 
 ## Installation
 
@@ -53,7 +57,7 @@ const pageMediaRequest: GetPageMediaRequest = client.newGetPageMediaRequest();
 You can also build each request yourself, and that won't be hard at all. You'll just have to pass the Access Token and the Page ID to each new request. Here's an example:
 
 ```typescript
-  const request: GetPageInfoRequest = new GetPageInfoRequest(ACCESS_TOKEN, PAGE_ID);
+const request: GetPageInfoRequest = new GetPageInfoRequest(ACCESS_TOKEN, PAGE_ID);
 ```
 
 ### Executing the requests
@@ -93,12 +97,12 @@ const config: RequestConfig = request.config();
 Publishing Media through the Instagram Graph API, and conversely through this lib, follows these steps:
 
 1. Create an IG Container object. The request will return the container id.
-   - For photos use `PostPagePhotoMediaRequest`.
-   - ~~For videos use `PostPageVideoMediaRequest`.~~ Instagram has removed the ability to publish normal/legacy videos through their API. Videos are now always reels.
-   - For reels use `PostPageReelMediaRequest`.
-   - For carousels check the [Publishing Carousels section below](#publishing-carousels).
-   - For Story videos use `PostPageStoryPhotoMediaRequest`
-   - For Story videos use `PostPageStoryVideoMediaRequest`
+    - For photos use `PostPagePhotoMediaRequest`.
+    - ~~For videos use `PostPageVideoMediaRequest`.~~ Instagram has removed the ability to publish normal/legacy videos through their API. Videos are now always reels.
+    - For reels use `PostPageReelMediaRequest`.
+    - For carousels check the [Publishing Carousels section below](#publishing-carousels).
+    - For Story videos use `PostPageStoryPhotoMediaRequest`
+    - For Story videos use `PostPageStoryVideoMediaRequest`
 2. Wait for the IG Container status to move to `FINISHED` (check the status through the `GetContainerRequest`).
 3. Publish the IG Container (through the `PostPublishMediaRequest`).
 

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [6.2.0](https://github.com/TiagoGrosso/instagram-graph-api-lib/compare/v6.1.1...v6.2.0) (2024-08-06)
+
+
+### Features
+
+* **comments:** add 'from' and 'parent_id' fields to comment data ([#395](https://github.com/TiagoGrosso/instagram-graph-api-lib/issues/395)) ([1a0cb14](https://github.com/TiagoGrosso/instagram-graph-api-lib/commit/1a0cb144de4e13896e1b324b89e3a67a56d026ea))
+
 ## [6.1.1](https://github.com/TiagoGrosso/instagram-graph-api-lib/compare/v6.1.0...v6.1.1) (2024-07-15)
 
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,5 +15,6 @@ const config: Config.InitialOptions = {
             statements: 95,
         },
     },
+    setupFiles: ['./src/test/SetupJest.ts'],
 };
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "instagram-graph-api",
             "version": "0.1.0",
             "license": "MIT",
-            "dependencies": {
-                "axios": "^0.28.0"
-            },
             "devDependencies": {
                 "@commitlint/cli": "^19.3.0",
                 "@commitlint/config-angular": "^19.3.0",
@@ -25,13 +22,13 @@
                 "@types/uuid": "^10.0.0",
                 "@typescript-eslint/eslint-plugin": "^8.0.0",
                 "@typescript-eslint/parser": "^8.0.0",
-                "axios-mock-adapter": "^1.19.0",
                 "create-ts-index": "^1.14.0",
                 "dotenv": "^16.0.3",
                 "eslint": "^8.27.0",
                 "eslint-config-google": "^0.14.0",
                 "husky": "^9.0.11",
                 "jest": "^29.7.0",
+                "jest-fetch-mock": "^3.0.3",
                 "prettier": "3.3.3",
                 "retry": "^0.13.1",
                 "rollup": "^2.52.2",
@@ -3175,43 +3172,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "license": "MIT"
-        },
-        "node_modules/axios": {
-            "version": "0.28.1",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.0",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
-        "node_modules/axios-mock-adapter": {
-            "version": "1.22.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "is-buffer": "^2.0.5"
-            },
-            "peerDependencies": {
-                "axios": ">= 0.17.0"
-            }
-        },
-        "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/babel-jest": {
             "version": "29.7.0",
             "dev": true,
@@ -3675,16 +3635,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/commander": {
             "version": "2.20.3",
             "dev": true,
@@ -3892,6 +3842,15 @@
                 "cti": "dist/cti.js"
             }
         },
+        "node_modules/cross-fetch": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+            "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+            "dev": true,
+            "dependencies": {
+                "node-fetch": "^2.6.12"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "dev": true,
@@ -4008,13 +3967,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/deprecation": {
@@ -4836,24 +4788,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/foreground-child": {
             "version": "3.2.1",
             "dev": true,
@@ -5433,28 +5367,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/is-buffer": {
-            "version": "2.0.5",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/is-builtin-module": {
             "version": "3.2.1",
             "dev": true,
@@ -6005,6 +5917,16 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-fetch-mock": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+            "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+            "dev": true,
+            "dependencies": {
+                "cross-fetch": "^3.0.4",
+                "promise-polyfill": "^8.1.3"
             }
         },
         "node_modules/jest-haste-map": {
@@ -7007,23 +6929,6 @@
                 "node": ">=16"
             }
         },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.35",
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
             "dev": true,
@@ -7116,6 +7021,26 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/node-int64": {
@@ -10393,6 +10318,12 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/promise-polyfill": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+            "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+            "dev": true
+        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "dev": true,
@@ -10410,10 +10341,6 @@
             "dev": true,
             "license": "ISC",
             "peer": true
-        },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "license": "MIT"
         },
         "node_modules/punycode": {
             "version": "2.1.1",
@@ -11638,6 +11565,12 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true
+        },
         "node_modules/traverse": {
             "version": "0.6.8",
             "dev": true,
@@ -12031,6 +11964,22 @@
             "license": "MIT",
             "dependencies": {
                 "defaults": "^1.0.3"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "author": "Tiago Grosso <tiagogrosso99@gmail.com>",
     "license": "MIT",
     "description": "A library to help perform requests to the Instagram Graph API.",
-    "dependencies": {
-        "axios": "^0.28.0"
-    },
     "devDependencies": {
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-angular": "^19.3.0",
@@ -43,13 +40,13 @@
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
-        "axios-mock-adapter": "^1.19.0",
         "create-ts-index": "^1.14.0",
         "dotenv": "^16.0.3",
         "eslint": "^8.27.0",
         "eslint-config-google": "^0.14.0",
         "husky": "^9.0.11",
         "jest": "^29.7.0",
+        "jest-fetch-mock": "^3.0.3",
         "prettier": "3.3.3",
         "retry": "^0.13.1",
         "rollup": "^2.52.2",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -5,7 +5,7 @@ import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import typescript from 'rollup-plugin-typescript2';
 import { terser } from 'rollup-plugin-terser';
 
-const packageJson = require('./package.json');
+import packageJson from './package.json';
 
 export default {
     input: 'src/Index.ts',
@@ -14,7 +14,6 @@ export default {
         format: 'cjs',
         sourcemap: process.env.NODE_ENV === 'dev' ? true : false,
     },
-    external: ['axios'],
     plugins: [
         peerDepsExternal(),
         resolve(),

--- a/src/it/page/GetPageInfo.test.ts
+++ b/src/it/page/GetPageInfo.test.ts
@@ -9,24 +9,21 @@ describe('GetPageInfo', () => {
         expect(result.getId()).toEqual(getPageId());
     });
 
-    Object.values(PageField)
-        .filter((field) => field != PageField.ID)
-        .forEach((field) => {
-            it(`Gets the page info with only '${field}'`, async () => {
-                const request = getClient().newGetPageInfoRequest(field);
-                const result = await request.execute();
-                Object.values(PageField)
-                    .filter(
-                        (expectedField) =>
-                            ![
-                                field,
-                                PageField.ID, // Always returned
-                            ].includes(expectedField)
-                    )
-                    .forEach((expectedField) => expect(result.getData()[expectedField]).toBeUndefined());
+    const fields = Object.values(PageField).filter((field) => field != PageField.ID);
+    it.each(fields)(`Gets the page info with only '$s'`, async (field) => {
+        const request = getClient().newGetPageInfoRequest(field);
+        const result = await request.execute();
+        Object.values(PageField)
+            .filter(
+                (expectedField) =>
+                    ![
+                        field,
+                        PageField.ID, // Always returned
+                    ].includes(expectedField)
+            )
+            .forEach((expectedField) => expect(result.getData()[expectedField]).toBeUndefined());
 
-                expect(result.getId()).toEqual(getPageId());
-                expect(result.getData()[field]).toBeDefined();
-            });
-        });
+        expect(result.getId()).toEqual(getPageId());
+        expect(result.getData()[field]).toBeDefined();
+    });
 });

--- a/src/it/page/PublishMediaRequests.test.ts
+++ b/src/it/page/PublishMediaRequests.test.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from 'axios';
 import retry from 'retry';
 import { MediaProductType, MediaTypeInResponses } from '../../main/Enums';
 import { CONTAINER_STATUS_CODE } from '../../main/requests/data/ContainerData';
@@ -146,9 +145,8 @@ async function createContainerAndWaitToBeReady(req: AbstractPostPageMediaRequest
         }
         return containerId;
     } catch (e) {
-        const error = e as AxiosError;
-        console.error(error.response?.data);
-        throw new Error(error.message);
+        console.error(e);
+        throw e;
     }
 }
 

--- a/src/main/requests/AbstractRequest.ts
+++ b/src/main/requests/AbstractRequest.ts
@@ -1,8 +1,7 @@
-import axios, { AxiosResponse } from 'axios';
 import { Method, RequestConfig } from './RequestConfig';
 import { AbstractResponse } from './AbstractResponse';
 import { Constants } from '../Constants';
-import { Params } from './Params';
+import { Params, paramsToURLSearchParams } from './Params';
 import { ApiVersion, PageOption } from '../Enums';
 
 /**
@@ -61,10 +60,17 @@ export abstract class AbstractRequest<R extends AbstractResponse<unknown>> {
      *
      * @returns the promise of a parsed response.
      */
-    public execute(): Promise<R> {
-        return axios(this.config()).then((response) => {
-            return this.parseResponse(response);
+    public async execute(): Promise<R> {
+        const config = this.config();
+        const url = `${config.baseURL}/${config.url}?${paramsToURLSearchParams(config.params)}`;
+
+        const request = new Request(url, {
+            method: config.method,
         });
+
+        const response = await fetch(request);
+        const parsed = await response.json();
+        return this.parseResponse(parsed);
     }
 
     /**
@@ -161,7 +167,7 @@ export abstract class AbstractRequest<R extends AbstractResponse<unknown>> {
      *
      * @param response the parsed response.
      */
-    protected abstract parseResponse(response: AxiosResponse<unknown>): R;
+    protected abstract parseResponse(response: unknown): R;
 
     /**
      * Gets the url for the request.

--- a/src/main/requests/Params.ts
+++ b/src/main/requests/Params.ts
@@ -44,3 +44,15 @@ export interface Params {
     creation_id?: string;
     share_to_feed?: boolean;
 }
+
+export function paramsToURLSearchParams(params: Params): URLSearchParams {
+    const urlParams = new URLSearchParams();
+
+    Object.entries(params).forEach(([key, value]) => {
+        if (value) {
+            urlParams.set(key, value.toString());
+        }
+    });
+
+    return urlParams;
+}

--- a/src/main/requests/comment/DeleteCommentRequest.ts
+++ b/src/main/requests/comment/DeleteCommentRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { Method } from '../RequestConfig';
 import { AbstractCommentRequest } from './AbstractCommentRequest';
 import { CommentUpdateResponse } from './CommentUpdateResponse';
@@ -13,8 +12,8 @@ export class DeleteCommentRequest extends AbstractCommentRequest<CommentUpdateRe
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): CommentUpdateResponse {
-        return new CommentUpdateResponse(response.data);
+    protected parseResponse(response: { success: boolean }): CommentUpdateResponse {
+        return new CommentUpdateResponse(response);
     }
 
     /**

--- a/src/main/requests/comment/GetCommentRequest.ts
+++ b/src/main/requests/comment/GetCommentRequest.ts
@@ -1,7 +1,7 @@
-import { AxiosResponse } from 'axios';
 import { CommentField } from '../../Enums';
 import { AbstractCommentRequest } from './AbstractCommentRequest';
 import { GetCommentResponse } from './GetCommentResponse';
+import { CommentData } from '../data/CommentData';
 
 /**
  * Request to get information about a comment.
@@ -26,7 +26,7 @@ export class GetCommentRequest extends AbstractCommentRequest<GetCommentResponse
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetCommentResponse {
-        return new GetCommentResponse(response.data);
+    protected parseResponse(response: CommentData): GetCommentResponse {
+        return new GetCommentResponse(response);
     }
 }

--- a/src/main/requests/comment/PostHideCommentRequest.ts
+++ b/src/main/requests/comment/PostHideCommentRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { Method } from '../RequestConfig';
 import { AbstractCommentRequest } from './AbstractCommentRequest';
 import { CommentUpdateResponse } from './CommentUpdateResponse';
@@ -25,8 +24,8 @@ export class PostHideCommentRequest extends AbstractCommentRequest<CommentUpdate
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): CommentUpdateResponse {
-        return new CommentUpdateResponse(response.data);
+    protected parseResponse(response: { success: boolean }): CommentUpdateResponse {
+        return new CommentUpdateResponse(response);
     }
 
     /**

--- a/src/main/requests/comment/replies/GetRepliesRequest.ts
+++ b/src/main/requests/comment/replies/GetRepliesRequest.ts
@@ -1,7 +1,7 @@
-import { AxiosResponse } from 'axios';
 import { CommentField } from '../../../Enums';
 import { GetObjectCommentsResponse } from '../../common/GetObjectCommentsResponse';
 import { AbstractRepliesRequest } from './AbstractRepliesRequest';
+import { CommentData } from '../../data/CommentData';
 
 /**
  * A request to get the replies to a comment.
@@ -27,7 +27,7 @@ export class GetRepliesRequest extends AbstractRepliesRequest<GetObjectCommentsR
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetObjectCommentsResponse {
-        return new GetObjectCommentsResponse(response.data);
+    protected parseResponse(response: { data: CommentData[] }): GetObjectCommentsResponse {
+        return new GetObjectCommentsResponse(response);
     }
 }

--- a/src/main/requests/comment/replies/PostReplyRequest.ts
+++ b/src/main/requests/comment/replies/PostReplyRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { CreatedObjectIdResponse } from '../../common/CreatedObjectIdResponse';
 import { Method } from '../../RequestConfig';
 import { AbstractRepliesRequest } from './AbstractRepliesRequest';
@@ -25,8 +24,8 @@ export class PostReplyRequest extends AbstractRepliesRequest<CreatedObjectIdResp
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): CreatedObjectIdResponse {
-        return new CreatedObjectIdResponse(response.data);
+    protected parseResponse(response: { id: string }): CreatedObjectIdResponse {
+        return new CreatedObjectIdResponse(response);
     }
 
     /**

--- a/src/main/requests/container/GetContainerRequest.ts
+++ b/src/main/requests/container/GetContainerRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { ContainerField } from '../../Enums';
 import { AbstractRequest } from '../AbstractRequest';
 import { ContainerData } from '../data/ContainerData';
@@ -33,8 +32,8 @@ export class GetContainerRequest extends AbstractRequest<GetContainerResponse> {
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<ContainerData>): GetContainerResponse {
-        return new GetContainerResponse(response.data);
+    protected parseResponse(response: ContainerData): GetContainerResponse {
+        return new GetContainerResponse(response);
     }
 
     /**

--- a/src/main/requests/hashtag/media/AbstractGetHashtagMediaRequest.ts
+++ b/src/main/requests/hashtag/media/AbstractGetHashtagMediaRequest.ts
@@ -1,7 +1,8 @@
-import { AxiosResponse } from 'axios';
 import { HashtagMediaField } from '../../../Enums';
 import { AbstractGetMediaRequest } from '../../AbstractGetMediaRequest';
 import { GetHashtagMediaResponse } from './GetHashtagMediaResponse';
+import { MediaData } from '../../data/MediaData';
+import { PagingData } from '../../data/Paging';
 
 /**
  * A request that gets information about the media of an hashtag.
@@ -33,8 +34,8 @@ export abstract class AbstractGetHashtagMediaRequest extends AbstractGetMediaReq
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetHashtagMediaResponse {
-        return new GetHashtagMediaResponse(response.data);
+    protected parseResponse(response: { data: MediaData[]; paging: PagingData }): GetHashtagMediaResponse {
+        return new GetHashtagMediaResponse(response);
     }
 
     /**

--- a/src/main/requests/hashtag/search/GetHashtagIdRequest.ts
+++ b/src/main/requests/hashtag/search/GetHashtagIdRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { GetHashtagIdResponse } from './GetHashtagIdResponse';
 
@@ -25,8 +24,8 @@ export class GetHashtagIdRequest extends AbstractRequest<GetHashtagIdResponse> {
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetHashtagIdResponse {
-        return new GetHashtagIdResponse(response.data);
+    protected parseResponse(response: { data: { id: string }[] }): GetHashtagIdResponse {
+        return new GetHashtagIdResponse(response);
     }
 
     /**

--- a/src/main/requests/media/children/GetMediaChildrenRequest.ts
+++ b/src/main/requests/media/children/GetMediaChildrenRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { GetMediaChildrenResponse } from './GetMediaChildrenResponse';
 
@@ -28,8 +27,8 @@ export class GetMediaChildrenRequest extends AbstractRequest<GetMediaChildrenRes
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetMediaChildrenResponse {
-        return new GetMediaChildrenResponse(response.data);
+    protected parseResponse(response: { data: { id: string }[] }): GetMediaChildrenResponse {
+        return new GetMediaChildrenResponse(response);
     }
 
     /**

--- a/src/main/requests/media/comments/GetMediaCommentsRequest.ts
+++ b/src/main/requests/media/comments/GetMediaCommentsRequest.ts
@@ -1,7 +1,7 @@
-import { AxiosResponse } from 'axios';
 import { CommentField } from '../../../Enums';
 import { GetObjectCommentsResponse } from '../../common/GetObjectCommentsResponse';
 import { AbstractMediaCommentsRequest } from './AbstractMediaCommentsRequest';
+import { CommentData } from '../../data/CommentData';
 
 /**
  * A request that gets the comments of a media object.
@@ -26,7 +26,7 @@ export class GetMediaCommentsRequest extends AbstractMediaCommentsRequest<GetObj
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetObjectCommentsResponse {
-        return new GetObjectCommentsResponse(response.data);
+    protected parseResponse(response: { data: CommentData[] }): GetObjectCommentsResponse {
+        return new GetObjectCommentsResponse(response);
     }
 }

--- a/src/main/requests/media/comments/PostMediaCommentRequest.ts
+++ b/src/main/requests/media/comments/PostMediaCommentRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { Method } from '../../RequestConfig';
 import { AbstractMediaCommentsRequest } from './AbstractMediaCommentsRequest';
 import { CreatedObjectIdResponse } from '../../common/CreatedObjectIdResponse';
@@ -25,8 +24,8 @@ export class PostMediaCommentRequest extends AbstractMediaCommentsRequest<Create
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): CreatedObjectIdResponse {
-        return new CreatedObjectIdResponse(response.data);
+    protected parseResponse(response: { id: string }): CreatedObjectIdResponse {
+        return new CreatedObjectIdResponse(response);
     }
 
     /**

--- a/src/main/requests/media/info/GetMediaInfoRequest.ts
+++ b/src/main/requests/media/info/GetMediaInfoRequest.ts
@@ -1,7 +1,7 @@
-import { AxiosResponse } from 'axios';
 import { MediaField, PublicMediaField } from '../../../Enums';
 import { AbstractGetMediaRequest } from '../../AbstractGetMediaRequest';
 import { GetMediaInfoResponse } from './GetMediaInfoResponse';
+import { MediaData } from '../../data/MediaData';
 
 /**
  * A request that gets information about a media object.
@@ -41,7 +41,7 @@ export class GetMediaInfoRequest extends AbstractGetMediaRequest<GetMediaInfoRes
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetMediaInfoResponse {
-        return new GetMediaInfoResponse(response.data);
+    protected parseResponse(response: MediaData): GetMediaInfoResponse {
+        return new GetMediaInfoResponse(response);
     }
 }

--- a/src/main/requests/media/insights/AbstractGetMediaInsightsRequest.ts
+++ b/src/main/requests/media/insights/AbstractGetMediaInsightsRequest.ts
@@ -1,7 +1,7 @@
-import { AxiosResponse } from 'axios';
 import { AlbumMetric, SimplePostMetric, StoryMetric } from '../../../Enums';
 import { AbstractRequest } from '../../AbstractRequest';
 import { GetMediaInsightsResponse } from './GetMediaInsightsResponse';
+import { BasicInsightsMetricData, MetricValue } from '../../data/insights/BasicInsightsMetricData';
 
 /**
  * An abstract class to represent request that gets insights about a media object.
@@ -42,7 +42,9 @@ export abstract class AbstractGetMediaInsightsRequest<
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetMediaInsightsResponse {
-        return new GetMediaInsightsResponse(response.data);
+    protected parseResponse(response: {
+        data: BasicInsightsMetricData<MetricValue<number>[]>[];
+    }): GetMediaInsightsResponse {
+        return new GetMediaInsightsResponse(response);
     }
 }

--- a/src/main/requests/page/authorized_facebook_pages/GetAuthorizedFacebookPagesRequest.ts
+++ b/src/main/requests/page/authorized_facebook_pages/GetAuthorizedFacebookPagesRequest.ts
@@ -1,5 +1,5 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
+import { AuthorizedFacebookPagesData } from '../../data/AuthorizedFacebookPagesData';
 import { GetAuthorizedFacebookPagesResponse } from './GetAuthorizedFacebookPagesResponse';
 
 /**
@@ -22,8 +22,8 @@ export class GetAuthorizedFacebookPagesRequest extends AbstractRequest<GetAuthor
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetAuthorizedFacebookPagesResponse {
-        return new GetAuthorizedFacebookPagesResponse(response.data);
+    protected parseResponse(response: AuthorizedFacebookPagesData): GetAuthorizedFacebookPagesResponse {
+        return new GetAuthorizedFacebookPagesResponse(response);
     }
 
     /**

--- a/src/main/requests/page/content_publishing_limit/GetContentPublishingLimitRequest.ts
+++ b/src/main/requests/page/content_publishing_limit/GetContentPublishingLimitRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { ContentPublishingLimitFields } from '../../../Enums';
 import { AbstractRequest } from '../../AbstractRequest';
 import { ContentPublishingLimitData } from '../../data/ContentPublishingLimitData';
@@ -34,10 +33,8 @@ export class GetContentPublishingLimitRequest extends AbstractRequest<GetContent
     /**
      * @inheritdoc
      */
-    protected parseResponse(
-        response: AxiosResponse<{ data: ContentPublishingLimitData[] }>
-    ): GetContentPublishingLimitResponse {
-        return new GetContentPublishingLimitResponse(response.data.data[0]);
+    protected parseResponse(response: { data: ContentPublishingLimitData[] }): GetContentPublishingLimitResponse {
+        return new GetContentPublishingLimitResponse(response.data[0]);
     }
 
     /**

--- a/src/main/requests/page/info/GetPageInfoRequest.ts
+++ b/src/main/requests/page/info/GetPageInfoRequest.ts
@@ -1,7 +1,7 @@
-import { AxiosResponse } from 'axios';
 import { GetPageInfoResponse } from './GetPageInfoResponse';
 import { AbstractRequest } from '../../AbstractRequest';
 import { PageField } from '../../../Enums';
+import { PageInfoData } from '../../data/PageInfoData';
 
 /**
  * A request that gets information about a page.
@@ -32,8 +32,8 @@ export class GetPageInfoRequest extends AbstractRequest<GetPageInfoResponse> {
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetPageInfoResponse {
-        return new GetPageInfoResponse(response.data);
+    protected parseResponse(response: PageInfoData): GetPageInfoResponse {
+        return new GetPageInfoResponse(response);
     }
 
     /**

--- a/src/main/requests/page/insights/AbstractGetPageTimedInsightsRequest.ts
+++ b/src/main/requests/page/insights/AbstractGetPageTimedInsightsRequest.ts
@@ -1,7 +1,8 @@
-import { AxiosResponse } from 'axios';
 import { DayMetric, WeekAndMonthMetric } from '../../../Enums';
 import { AbstractGetPageInsightsRequest } from './AbstractGetPageInsightsRequest';
 import { GetPageTimedInsightsResponse } from './GetPageTimedInsightsResponse';
+import { BasicInsightsMetricData, MetricValue } from '../../data/insights/BasicInsightsMetricData';
+import { PagingData } from '../../data/Paging';
 
 /**
  * An abstract class to represent Page Insights Get Requests that query a metric that is time bound.
@@ -17,7 +18,10 @@ export abstract class AbstractGetPageTimedInsightsRequest<
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetPageTimedInsightsResponse {
-        return new GetPageTimedInsightsResponse(response.data);
+    protected parseResponse(response: {
+        data: BasicInsightsMetricData<MetricValue<number>[]>[];
+        paging: PagingData;
+    }): GetPageTimedInsightsResponse {
+        return new GetPageTimedInsightsResponse(response);
     }
 }

--- a/src/main/requests/page/insights/GetPageLifetimeInsightsRequest.ts
+++ b/src/main/requests/page/insights/GetPageLifetimeInsightsRequest.ts
@@ -1,7 +1,8 @@
-import { AxiosResponse } from 'axios';
 import { LifetimeMetric, MetricPeriod } from '../../../Enums';
 import { AbstractGetPageInsightsRequest } from './AbstractGetPageInsightsRequest';
 import { GetPageLifetimeInsightsResponse } from './GetPageLifetimeInsightsResponse';
+import { BasicInsightsMetricData, MetricValue } from '../../data/insights/BasicInsightsMetricData';
+import { ComplexMetricValue } from '../../data/insights/ComplexMetric';
 
 /**
  * A Page Insights Get Request that queries a lifetime metric.
@@ -28,8 +29,10 @@ export class GetPageLifetimeInsightsRequest extends AbstractGetPageInsightsReque
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetPageLifetimeInsightsResponse {
-        return new GetPageLifetimeInsightsResponse(response.data);
+    protected parseResponse(response: {
+        data: BasicInsightsMetricData<MetricValue<ComplexMetricValue>[]>[];
+    }): GetPageLifetimeInsightsResponse {
+        return new GetPageLifetimeInsightsResponse(response);
     }
 
     /**

--- a/src/main/requests/page/instagram_account_info/GetInstagramAccountInfoRequest.ts
+++ b/src/main/requests/page/instagram_account_info/GetInstagramAccountInfoRequest.ts
@@ -1,6 +1,6 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { GetInstagramAccountInfoResponse } from './GetInstagramAccountInfoResponse';
+import { InstagramAccountInfoData } from '../../data/InstagramAccountInfoData';
 
 /**
  * A Get request to obtain information about an Instagram account.
@@ -29,8 +29,8 @@ export class GetInstagramAccountInfoRequest extends AbstractRequest<GetInstagram
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetInstagramAccountInfoResponse {
-        return new GetInstagramAccountInfoResponse(response.data);
+    protected parseResponse(response: InstagramAccountInfoData): GetInstagramAccountInfoResponse {
+        return new GetInstagramAccountInfoResponse(response);
     }
 
     /**

--- a/src/main/requests/page/linked_instagram_account/GetLinkedInstagramAccountRequest.ts
+++ b/src/main/requests/page/linked_instagram_account/GetLinkedInstagramAccountRequest.ts
@@ -1,6 +1,6 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { GetLinkedInstagramAccountResponse } from './GetLinkedInstagramAccountResponse';
+import { LinkedInstagramAccountData } from '../../data/LinkedInstagramAccountData';
 
 /**
  * A Get request to obtain instagram_business_account information related with
@@ -33,8 +33,8 @@ export class GetLinkedInstagramAccountRequest extends AbstractRequest<GetLinkedI
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetLinkedInstagramAccountResponse {
-        return new GetLinkedInstagramAccountResponse(response.data);
+    protected parseResponse(response: LinkedInstagramAccountData): GetLinkedInstagramAccountResponse {
+        return new GetLinkedInstagramAccountResponse(response);
     }
 
     /**

--- a/src/main/requests/page/media/AbstractPostPageMediaRequest.ts
+++ b/src/main/requests/page/media/AbstractPostPageMediaRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { CreatedObjectIdResponse } from '../../common/CreatedObjectIdResponse';
 import { Method } from '../../RequestConfig';
@@ -30,8 +29,8 @@ export abstract class AbstractPostPageMediaRequest extends AbstractRequest<Creat
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<{ id: string }>): CreatedObjectIdResponse {
-        return new CreatedObjectIdResponse(response.data);
+    protected parseResponse(response: { id: string }): CreatedObjectIdResponse {
+        return new CreatedObjectIdResponse(response);
     }
 
     /**

--- a/src/main/requests/page/media/GetPageMediaRequest.ts
+++ b/src/main/requests/page/media/GetPageMediaRequest.ts
@@ -1,7 +1,8 @@
-import { AxiosResponse } from 'axios';
 import { MediaField } from '../../../Enums';
 import { AbstractGetMediaRequest } from '../../AbstractGetMediaRequest';
 import { GetPageMediaResponse } from './GetPageMediaResponse';
+import { MediaData } from '../../data/MediaData';
+import { PagingData } from '../../data/Paging';
 
 /**
  * A request that gets information about the media of a page.
@@ -37,7 +38,7 @@ export class GetPageMediaRequest extends AbstractGetMediaRequest<GetPageMediaRes
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetPageMediaResponse {
-        return new GetPageMediaResponse(response.data);
+    protected parseResponse(response: { data: MediaData[]; paging: PagingData }): GetPageMediaResponse {
+        return new GetPageMediaResponse(response);
     }
 }

--- a/src/main/requests/page/media_publish/PostPublishMediaRequest.ts
+++ b/src/main/requests/page/media_publish/PostPublishMediaRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { CreatedObjectIdResponse } from '../../common/CreatedObjectIdResponse';
 import { Method } from '../../RequestConfig';
@@ -31,8 +30,8 @@ export class PostPublishMediaRequest extends AbstractRequest<CreatedObjectIdResp
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<{ id: string }>): CreatedObjectIdResponse {
-        return new CreatedObjectIdResponse(response.data);
+    protected parseResponse(response: { id: string }): CreatedObjectIdResponse {
+        return new CreatedObjectIdResponse(response);
     }
 
     /**

--- a/src/main/requests/page/recently_searched_hashtags/GetPageRecentlySearchedHashtagsRequest.ts
+++ b/src/main/requests/page/recently_searched_hashtags/GetPageRecentlySearchedHashtagsRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { ManyIdsResponse } from '../../common/ManyIdsResponse';
 import { PagingData } from '../../data/Paging';
@@ -29,8 +28,8 @@ export class GetPageRecentlySearchedHashtagsRequest extends AbstractRequest<Many
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<{ data: { id: string }[]; paging: PagingData }>): ManyIdsResponse {
-        return new ManyIdsResponse({ data: response.data.data, paging: response.data.paging });
+    protected parseResponse(response: { data: { id: string }[]; paging: PagingData }): ManyIdsResponse {
+        return new ManyIdsResponse({ data: response.data, paging: response.paging });
     }
 
     /**

--- a/src/main/requests/page/stories/GetPageStoriesRequest.ts
+++ b/src/main/requests/page/stories/GetPageStoriesRequest.ts
@@ -1,4 +1,3 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { ManyIdsResponse } from '../../common/ManyIdsResponse';
 import { PagingData } from '../../data/Paging';
@@ -29,8 +28,8 @@ export class GetPageStoriesRequest extends AbstractRequest<ManyIdsResponse> {
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<{ data: { id: string }[]; paging: PagingData }>): ManyIdsResponse {
-        return new ManyIdsResponse({ data: response.data.data, paging: response.data.paging });
+    protected parseResponse(response: { data: { id: string }[]; paging: PagingData }): ManyIdsResponse {
+        return new ManyIdsResponse({ data: response.data, paging: response.paging });
     }
 
     /**

--- a/src/main/requests/page/tags/GetTagsRequest.ts
+++ b/src/main/requests/page/tags/GetTagsRequest.ts
@@ -1,6 +1,6 @@
-import { AxiosResponse } from 'axios';
 import { MediaField, PublicMediaField } from '../../../Enums';
 import { AbstractGetMediaRequest } from '../../AbstractGetMediaRequest';
+import { MediaData } from '../../data/MediaData';
 import { GetTagsResponse } from './GetTagsResponse';
 
 /**
@@ -42,7 +42,7 @@ export class GetTagsRequest extends AbstractGetMediaRequest<GetTagsResponse> {
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetTagsResponse {
-        return new GetTagsResponse(response.data);
+    protected parseResponse(request: { data: MediaData[] }): GetTagsResponse {
+        return new GetTagsResponse(request);
     }
 }

--- a/src/main/requests/page/user_long_lived_token/GetUserLongLivedTokenRequest.ts
+++ b/src/main/requests/page/user_long_lived_token/GetUserLongLivedTokenRequest.ts
@@ -1,6 +1,6 @@
-import { AxiosResponse } from 'axios';
 import { AbstractRequest } from '../../AbstractRequest';
 import { GetUserLongLivedTokenResponse } from './GetUserLongLivedTokenResponse';
+import { UserLongLivedTokenData } from '../../data/UserLongLivedTokenData';
 
 /**
  *  When requesting a long-lived access token on behalf of the user that is
@@ -46,8 +46,8 @@ export class GetUserLongLivedTokenRequest extends AbstractRequest<GetUserLongLiv
     /**
      * @inheritdoc
      */
-    protected parseResponse(response: AxiosResponse<never>): GetUserLongLivedTokenResponse {
-        return new GetUserLongLivedTokenResponse(response.data);
+    protected parseResponse(response: UserLongLivedTokenData): GetUserLongLivedTokenResponse {
+        return new GetUserLongLivedTokenResponse(response);
     }
 
     /**

--- a/src/test/SetupJest.ts
+++ b/src/test/SetupJest.ts
@@ -1,0 +1,2 @@
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();

--- a/src/test/TestConstants.ts
+++ b/src/test/TestConstants.ts
@@ -186,6 +186,7 @@ export class TestConstants {
                 id: 'from_user_id',
                 username: 'from_username',
             },
+            parent_id: 'parent_id',
         },
     ];
 

--- a/src/test/requests/AbstractRequest.test.ts
+++ b/src/test/requests/AbstractRequest.test.ts
@@ -1,14 +1,13 @@
-import axios, { AxiosResponse } from 'axios';
-import MockAdapter from 'axios-mock-adapter';
 import { Constants } from '../../main/Constants';
 import { ApiVersion } from '../../main/Enums';
 import { AbstractRequest } from '../../main/requests/AbstractRequest';
 import { AbstractResponse } from '../../main/requests/AbstractResponse';
+import { MediaData } from '../../main/requests/data/MediaData';
 import { TestConstants } from '../TestConstants';
 
 describe('AbstractRequest', () => {
     class AbstractRequestImpl extends AbstractRequest<AbstractResponseImpl> {
-        protected parseResponse(response: AxiosResponse): AbstractResponseImpl {
+        protected parseResponse(response: MediaData): AbstractResponseImpl {
             return new AbstractResponseImpl(response);
         }
         protected url(): string {
@@ -20,23 +19,19 @@ describe('AbstractRequest', () => {
         }
     }
 
-    class AbstractResponseImpl extends AbstractResponse<AxiosResponse> {
-        constructor(response: AxiosResponse) {
+    class AbstractResponseImpl extends AbstractResponse<MediaData> {
+        constructor(response: MediaData) {
             super(response);
         }
     }
 
     const request: AbstractRequestImpl = new AbstractRequestImpl();
 
-    const mock = new MockAdapter(axios);
-    mock.onAny().reply(200, TestConstants.FULL_MEDIA_DATA);
+    fetchMock.mockOnce(JSON.stringify(TestConstants.FULL_MEDIA_DATA));
 
-    it('Executes the request', () => {
-        expect.assertions(2);
-        return request.execute().then((response) => {
-            expect(response.getData().status).toEqual(200);
-            expect(response.getData().data).toEqual(TestConstants.FULL_MEDIA_DATA);
-        });
+    it('Executes the request', async () => {
+        const response = await request.execute();
+        expect(response.getData()).toEqual(TestConstants.FULL_MEDIA_DATA);
     });
 
     it('Builds a config', () => {

--- a/src/test/requests/comment/DeleteCommentRequest.test.ts
+++ b/src/test/requests/comment/DeleteCommentRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CommentUpdateResponse } from '../../../main/requests/comment/CommentUpdateResponse';
 import { DeleteCommentRequest } from '../../../main/requests/comment/DeleteCommentRequest';
 import { TestConstants } from '../../TestConstants';
@@ -16,12 +14,10 @@ describe('DeleteCommentRequest', () => {
         expect(request.config().url).toEqual(`/${TestConstants.COMMENT_ID}`);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onDelete(`${Constants.API_URL}/${TestConstants.COMMENT_ID}`).reply(200, { success: true });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify({ success: true }));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CommentUpdateResponse({ success: true }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CommentUpdateResponse({ success: true }));
     });
 });

--- a/src/test/requests/comment/GetCommentRequest.test.ts
+++ b/src/test/requests/comment/GetCommentRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CommentField } from '../../../main/Enums';
 import { GetCommentRequest } from '../../../main/requests/comment/GetCommentRequest';
 import { GetCommentResponse } from '../../../main/requests/comment/GetCommentResponse';
@@ -25,12 +23,10 @@ describe('GetCommentRequest', () => {
         expect(requestAllFields.config().params.fields).toEqual(Object.values(CommentField).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.COMMENT_ID}`).reply(200, TestConstants.COMMENTS_DATA[1]);
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify(TestConstants.COMMENTS_DATA[1]));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetCommentResponse(TestConstants.COMMENTS_DATA[1]));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetCommentResponse(TestConstants.COMMENTS_DATA[1]));
     });
 });

--- a/src/test/requests/comment/GetCommentResponse.test.ts
+++ b/src/test/requests/comment/GetCommentResponse.test.ts
@@ -63,4 +63,9 @@ describe('GetCommentResponse', () => {
         expect(bareResponse.getFrom()).toBeUndefined();
         expect(response.getFrom()).toEqual(TestConstants.COMMENTS_DATA[1].from);
     });
+
+    it('Gets the "parent_id" object', () => {
+        expect(bareResponse.getParentId()).toBeUndefined();
+        expect(response.getParentId()).toEqual(TestConstants.COMMENTS_DATA[1].parent_id);
+    });
 });

--- a/src/test/requests/comment/PostHideCommentRequest.test.ts
+++ b/src/test/requests/comment/PostHideCommentRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CommentUpdateResponse } from '../../../main/requests/comment/CommentUpdateResponse';
 import { PostHideCommentRequest } from '../../../main/requests/comment/PostHideCommentRequest';
 import { TestConstants } from '../../TestConstants';
@@ -23,12 +21,10 @@ describe('PostHideCommentRequest', () => {
         expect(requestExplicit.config().params.hide).toEqual(false);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.COMMENT_ID}`).reply(200, { success: true });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify({ success: true }));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return requestDefault.execute().then((response) => {
-            expect(response).toEqual(new CommentUpdateResponse({ success: true }));
-        });
+        const response = await requestDefault.execute();
+        expect(response).toEqual(new CommentUpdateResponse({ success: true }));
     });
 });

--- a/src/test/requests/comment/replies/GetRepliesRequest.test.ts
+++ b/src/test/requests/comment/replies/GetRepliesRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CommentField } from '../../../../main/Enums';
 import { GetRepliesRequest } from '../../../../main/requests/comment/replies/GetRepliesRequest';
 import { GetObjectCommentsResponse } from '../../../../main/requests/common/GetObjectCommentsResponse';
@@ -36,14 +34,14 @@ describe('GetRepliesRequest', () => {
         );
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.COMMENT_ID}/replies`).reply(200, {
-        data: TestConstants.COMMENTS_DATA,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: TestConstants.COMMENTS_DATA,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetObjectCommentsResponse({ data: TestConstants.COMMENTS_DATA }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetObjectCommentsResponse({ data: TestConstants.COMMENTS_DATA }));
     });
 });

--- a/src/test/requests/comment/replies/PostReplyRequest.test.ts
+++ b/src/test/requests/comment/replies/PostReplyRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { PostReplyRequest } from '../../../../main/requests/comment/replies/PostReplyRequest';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -18,14 +16,14 @@ describe('GetRepliesRequest', () => {
         expect(request.config().params.message).toEqual(TestConstants.COMMENT_TEXT);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.COMMENT_ID}/replies`).reply(200, {
-        id: TestConstants.COMMENT_ID,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            id: TestConstants.COMMENT_ID,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.COMMENT_ID }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.COMMENT_ID }));
     });
 });

--- a/src/test/requests/container/GetContainerRequest.test.ts
+++ b/src/test/requests/container/GetContainerRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { ContainerField } from '../../../main/Enums';
 import { GetContainerRequest } from '../../../main/requests/container/GetContainerRequest';
 import { GetContainerResponse } from '../../../main/requests/container/GetContainerResponse';
@@ -24,18 +22,18 @@ describe('GetContainerRequest', () => {
         expect(requestAllFields.config().params.fields).toEqual(Object.values(ContainerField).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.CONTAINER_ID}`).reply(200, {
-        id: TestConstants.CONTAINER_ID,
-        status: TestConstants.CONTAINER_STATUS,
-    });
+    fetchMock.mockOnce(
+        JSON.stringify({
+            id: TestConstants.CONTAINER_ID,
+            status: TestConstants.CONTAINER_STATUS,
+        })
+    );
 
-    it('Parses the response', () => {
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new GetContainerResponse({ id: TestConstants.CONTAINER_ID, status: TestConstants.CONTAINER_STATUS })
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(
+            new GetContainerResponse({ id: TestConstants.CONTAINER_ID, status: TestConstants.CONTAINER_STATUS })
+        );
     });
 });

--- a/src/test/requests/hashtag/media/AbstractGetHashtagMediaRequest.test.ts
+++ b/src/test/requests/hashtag/media/AbstractGetHashtagMediaRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { HashtagMediaField } from '../../../../main/Enums';
 import { AbstractGetHashtagMediaRequest } from '../../../../main/requests/hashtag/media/AbstractGetHashtagMediaRequest';
 import { GetPageMediaResponse } from '../../../../main/requests/page/media/GetPageMediaResponse';
@@ -32,20 +30,20 @@ describe('AbstractGetHashtagMediaRequest', () => {
         expect(requestAllFields.config().params.fields).toEqual(Object.values(HashtagMediaField).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.HASHTAG_ID}`).reply(200, {
-        data: [TestConstants.HASHTAG_ALBUM_MEDIA_DATA, TestConstants.HASHTAG_IMAGE_MEDIA_DATA],
-        paging: TestConstants.PAGING,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: [TestConstants.HASHTAG_ALBUM_MEDIA_DATA, TestConstants.HASHTAG_IMAGE_MEDIA_DATA],
+            paging: TestConstants.PAGING,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new GetPageMediaResponse({
-                    data: [TestConstants.HASHTAG_ALBUM_MEDIA_DATA, TestConstants.HASHTAG_IMAGE_MEDIA_DATA],
-                    paging: TestConstants.PAGING,
-                })
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(
+            new GetPageMediaResponse({
+                data: [TestConstants.HASHTAG_ALBUM_MEDIA_DATA, TestConstants.HASHTAG_IMAGE_MEDIA_DATA],
+                paging: TestConstants.PAGING,
+            })
+        );
     });
 });

--- a/src/test/requests/hashtag/search/GetHashtagIdRequest.test.ts
+++ b/src/test/requests/hashtag/search/GetHashtagIdRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetHashtagIdRequest } from '../../../../main/requests/hashtag/search/GetHashtagIdRequest';
 import { GetHashtagIdResponse } from '../../../../main/requests/hashtag/search/GetHashtagIdResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -15,12 +13,10 @@ describe('GetHashtagIdRequest', () => {
         expect(request.config().url).toEqual('/ig_hashtag_search');
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/ig_hashtag_search`).reply(200, { data: [{ id: TestConstants.HASHTAG_ID }] });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify({ data: [{ id: TestConstants.HASHTAG_ID }] }));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetHashtagIdResponse({ data: [{ id: TestConstants.HASHTAG_ID }] }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetHashtagIdResponse({ data: [{ id: TestConstants.HASHTAG_ID }] }));
     });
 });

--- a/src/test/requests/media/children/GetMediaChildrenRequest.test.ts
+++ b/src/test/requests/media/children/GetMediaChildrenRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetMediaChildrenRequest } from '../../../../main/requests/media/children/GetMediaChildrenRequest';
 import { GetMediaChildrenResponse } from '../../../../main/requests/media/children/GetMediaChildrenResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -16,14 +14,14 @@ describe('GetMediaCommentsRequest', () => {
         expect(request.config().url).toEqual(`/${TestConstants.MEDIA_ID}/children`);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.MEDIA_ID}/children`).reply(200, {
-        data: TestConstants.CHILDREN_DATA,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: TestConstants.CHILDREN_DATA,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetMediaChildrenResponse({ data: TestConstants.CHILDREN_DATA }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetMediaChildrenResponse({ data: TestConstants.CHILDREN_DATA }));
     });
 });

--- a/src/test/requests/media/comments/GetMediaCommentsRequest.test.ts
+++ b/src/test/requests/media/comments/GetMediaCommentsRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CommentField } from '../../../../main/Enums';
 import { GetMediaCommentsRequest } from '../../../../main/requests/media/comments/GetMediaCommentsRequest';
 import { GetObjectCommentsResponse } from '../../../../main/requests/common/GetObjectCommentsResponse';
@@ -25,14 +23,14 @@ describe('GetMediaCommentsRequest', () => {
         expect(requestAllFields.config().params.fields).toEqual(Object.values(CommentField).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.MEDIA_ID}/comments`).reply(200, {
-        data: TestConstants.COMMENTS_DATA,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: TestConstants.COMMENTS_DATA,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetObjectCommentsResponse({ data: TestConstants.COMMENTS_DATA }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetObjectCommentsResponse({ data: TestConstants.COMMENTS_DATA }));
     });
 });

--- a/src/test/requests/media/comments/PostMediaCommentRequest.test.ts
+++ b/src/test/requests/media/comments/PostMediaCommentRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { PostMediaCommentRequest } from '../../../../main/requests/media/comments/PostMediaCommentRequest';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -17,14 +15,14 @@ describe('GetMediaCommentsRequest', () => {
         expect(request.config().url).toEqual(`/${TestConstants.MEDIA_ID}/comments`);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.MEDIA_ID}/comments`).reply(200, {
-        id: TestConstants.COMMENT_ID,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            id: TestConstants.COMMENT_ID,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.COMMENT_ID }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.COMMENT_ID }));
     });
 });

--- a/src/test/requests/media/info/GetMediaInfoRequest.test.ts
+++ b/src/test/requests/media/info/GetMediaInfoRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { PrivateMediaField, PublicMediaField } from '../../../../main/Enums';
 import { GetMediaInfoRequest } from '../../../../main/requests/media/info/GetMediaInfoRequest';
 import { GetMediaInfoResponse } from '../../../../main/requests/media/info/GetMediaInfoResponse';
@@ -31,12 +29,10 @@ describe('GetMediaInfoRequest', () => {
         );
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.MEDIA_ID}`).reply(200, TestConstants.PARTIAL_MEDIA_DATA);
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify(TestConstants.PARTIAL_MEDIA_DATA));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetMediaInfoResponse(TestConstants.PARTIAL_MEDIA_DATA));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetMediaInfoResponse(TestConstants.PARTIAL_MEDIA_DATA));
     });
 });

--- a/src/test/requests/media/insights/GetAlbumMediaInsightsRequest.test.ts
+++ b/src/test/requests/media/insights/GetAlbumMediaInsightsRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { AlbumMetric } from '../../../../main/Enums';
 import { GetAlbumMediaInsightsRequest } from '../../../../main/requests/media/insights/GetAlbumMediaInsightsRequest';
 import { GetMediaInsightsResponse } from '../../../../main/requests/media/insights/GetMediaInsightsResponse';
@@ -24,14 +22,14 @@ describe('GetAlbumMediaInsightsRequest', () => {
         expect(allFieldsRequest.config().params.metric).toEqual(Object.values(AlbumMetric).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.MEDIA_ID}/insights`).reply(200, {
-        data: TestConstants.SIMPLE_METRIC_DATA,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: TestConstants.SIMPLE_METRIC_DATA,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetMediaInsightsResponse({ data: TestConstants.SIMPLE_METRIC_DATA }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetMediaInsightsResponse({ data: TestConstants.SIMPLE_METRIC_DATA }));
     });
 });

--- a/src/test/requests/media/insights/GetSimplePostMediaInsightsRequest.test.ts
+++ b/src/test/requests/media/insights/GetSimplePostMediaInsightsRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetSimplePostMediaInsightsRequest } from '../../../../main/requests/media/insights/GetSimplePostMediaInsightsRequest';
 import { GetMediaInsightsResponse } from '../../../../main/requests/media/insights/GetMediaInsightsResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -24,14 +22,14 @@ describe('GetSimplePostMediaInsightsRequest', () => {
         expect(allFieldsRequest.config().params.metric).toEqual(Object.values(SimplePostMetric).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.MEDIA_ID}/insights`).reply(200, {
-        data: TestConstants.SIMPLE_METRIC_DATA,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: TestConstants.SIMPLE_METRIC_DATA,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetMediaInsightsResponse({ data: TestConstants.SIMPLE_METRIC_DATA }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetMediaInsightsResponse({ data: TestConstants.SIMPLE_METRIC_DATA }));
     });
 });

--- a/src/test/requests/media/insights/GetStoryMediaInsightsRequest.test.ts
+++ b/src/test/requests/media/insights/GetStoryMediaInsightsRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { StoryMetric } from '../../../../main/Enums';
 import { GetMediaInsightsResponse } from '../../../../main/requests/media/insights/GetMediaInsightsResponse';
 import { GetStoryMediaInsightsRequest } from '../../../../main/requests/media/insights/GetStoryMediaInsightsRequest';
@@ -22,14 +20,14 @@ describe('GetStoryMediaInsightsRequest', () => {
         expect(allFieldsRequest.config().params.metric).toEqual(Object.values(StoryMetric).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.MEDIA_ID}/insights`).reply(200, {
-        data: TestConstants.SIMPLE_METRIC_DATA,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: TestConstants.SIMPLE_METRIC_DATA,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetMediaInsightsResponse({ data: TestConstants.SIMPLE_METRIC_DATA }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetMediaInsightsResponse({ data: TestConstants.SIMPLE_METRIC_DATA }));
     });
 });

--- a/src/test/requests/page/authorized_facebook_pages/GetAuthorizedFacebookPagesRequest.test.ts
+++ b/src/test/requests/page/authorized_facebook_pages/GetAuthorizedFacebookPagesRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetAuthorizedFacebookPagesRequest } from '../../../../main/requests/page/authorized_facebook_pages/GetAuthorizedFacebookPagesRequest';
 import { GetAuthorizedFacebookPagesResponse } from '../../../../main/requests/page/authorized_facebook_pages/GetAuthorizedFacebookPagesResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -15,12 +13,9 @@ describe('GetPageInfoRequest', () => {
         expect(request.config().url).toEqual('/me/accounts');
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/me/accounts`).reply(200, TestConstants.AUTHORIZED_FACEBOOK_PAGES);
-    it('Parses the response', () => {
-        expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetAuthorizedFacebookPagesResponse(TestConstants.AUTHORIZED_FACEBOOK_PAGES));
-        });
+    fetchMock.mockOnce(JSON.stringify(TestConstants.AUTHORIZED_FACEBOOK_PAGES));
+    it('Parses the response', async () => {
+        const response = await request.execute();
+        expect(response).toEqual(new GetAuthorizedFacebookPagesResponse(TestConstants.AUTHORIZED_FACEBOOK_PAGES));
     });
 });

--- a/src/test/requests/page/content_publishing_limit/GetContentPublishingLimitRequest.test.ts
+++ b/src/test/requests/page/content_publishing_limit/GetContentPublishingLimitRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { ContentPublishingLimitFields } from '../../../../main/Enums';
 import {
     DateOlderThanOneDay,
@@ -35,28 +33,26 @@ describe('GetContentPublishingLimitRequest', () => {
 
     it('Throws on an invalid "since" date', () => {
         const date: Date = new Date('20 Dec 1980');
-        expect(() => request.since(date)).toThrowError(new DateOlderThanOneDay(date));
+        expect(() => request.since(date)).toThrow(new DateOlderThanOneDay(date));
     });
 
     it('Throws on trying to add a range', () => {
-        expect(() => request.addRange(new Date(), new Date())).toThrowError(
+        expect(() => request.addRange(new Date(), new Date())).toThrow(
             new Error('For GetContentPublishingLimitRequest, use "since(date)" instead.')
         );
-        expect(() => request.withRange(new Date(), new Date())).toThrowError(
+        expect(() => request.withRange(new Date(), new Date())).toThrow(
             new Error('For GetContentPublishingLimitRequest, use "since(date)" instead.')
         );
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}/content_publishing_limit`).reply(200, {
-        data: [TestConstants.CONTENT_PUBLISHING_LIMIT_DATA],
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: [TestConstants.CONTENT_PUBLISHING_LIMIT_DATA],
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new GetContentPublishingLimitResponse(TestConstants.CONTENT_PUBLISHING_LIMIT_DATA)
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetContentPublishingLimitResponse(TestConstants.CONTENT_PUBLISHING_LIMIT_DATA));
     });
 });

--- a/src/test/requests/page/info/GetPageInfoRequest.test.ts
+++ b/src/test/requests/page/info/GetPageInfoRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { PageField } from '../../../../main/Enums';
 import { GetPageInfoRequest } from '../../../../main/requests/page/info/GetPageInfoRequest';
 import { GetPageInfoResponse } from '../../../../main/requests/page/info/GetPageInfoResponse';
@@ -27,12 +25,10 @@ describe('GetPageInfoRequest', () => {
         expect(requestAllFields.config().params.fields).toEqual(Object.values(PageField).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}`).reply(200, TestConstants.PAGE_INFO_DATA);
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify(TestConstants.PAGE_INFO_DATA));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetPageInfoResponse(TestConstants.PAGE_INFO_DATA));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetPageInfoResponse(TestConstants.PAGE_INFO_DATA));
     });
 });

--- a/src/test/requests/page/insights/AbstractGetPageInsightsRequest.test.ts
+++ b/src/test/requests/page/insights/AbstractGetPageInsightsRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { MetricPeriod } from '../../../../main/Enums';
 import { AbstractGetPageTimedInsightsRequest } from '../../../../main/requests/page/insights/AbstractGetPageTimedInsightsRequest';
 import { GetPageTimedInsightsResponse } from '../../../../main/requests/page/insights/GetPageTimedInsightsResponse';
@@ -18,20 +16,20 @@ describe('AbstractGetPageInsightsRequest', () => {
 
     const request: AbstractPageInsightsRequestImpl = new AbstractPageInsightsRequestImpl();
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}/insights`).reply(200, {
-        data: TestConstants.SIMPLE_METRIC_DATA,
-        paging: TestConstants.PAGING,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: TestConstants.SIMPLE_METRIC_DATA,
+            paging: TestConstants.PAGING,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new GetPageTimedInsightsResponse({
-                    data: TestConstants.SIMPLE_METRIC_DATA,
-                    paging: TestConstants.PAGING,
-                })
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(
+            new GetPageTimedInsightsResponse({
+                data: TestConstants.SIMPLE_METRIC_DATA,
+                paging: TestConstants.PAGING,
+            })
+        );
     });
 });

--- a/src/test/requests/page/insights/GetPageInsightsLifetimeRequest.test.ts
+++ b/src/test/requests/page/insights/GetPageInsightsLifetimeRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { LifetimeMetric, MetricPeriod } from '../../../../main/Enums';
 import { GetPageLifetimeInsightsRequest } from '../../../../main/requests/page/insights/GetPageLifetimeInsightsRequest';
 import { GetPageLifetimeInsightsResponse } from '../../../../main/requests/page/insights/GetPageLifetimeInsightsResponse';
@@ -28,18 +26,18 @@ describe('GetPageLifetimeInsightsRequest', () => {
         expect(allFieldsRequest.config().params.metric).toEqual(Object.values(LifetimeMetric).join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}/insights`).reply(200, {
-        data: TestConstants.COMPLEX_METRIC_DATA,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: TestConstants.COMPLEX_METRIC_DATA,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new GetPageLifetimeInsightsResponse({
-                    data: TestConstants.COMPLEX_METRIC_DATA,
-                })
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(
+            new GetPageLifetimeInsightsResponse({
+                data: TestConstants.COMPLEX_METRIC_DATA,
+            })
+        );
     });
 });

--- a/src/test/requests/page/instagram_account_info/GetInstagramAccountInfoRequest.test.ts
+++ b/src/test/requests/page/instagram_account_info/GetInstagramAccountInfoRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetInstagramAccountInfoRequest } from '../../../../main/requests/page/instagram_account_info/GetInstagramAccountInfoRequest';
 import { GetInstagramAccountInfoResponse } from '../../../../main/requests/page/instagram_account_info/GetInstagramAccountInfoResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -16,12 +14,10 @@ describe('GetInstagramAccountInfoRequest', () => {
         expect(request.config().url).toEqual(`/${TestConstants.INSTAGRAM_ID}`);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.INSTAGRAM_ID}`).reply(200, TestConstants.INSTAGRAM_ACCOUNT_DATA);
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify(TestConstants.INSTAGRAM_ACCOUNT_DATA));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetInstagramAccountInfoResponse(TestConstants.INSTAGRAM_ACCOUNT_DATA));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetInstagramAccountInfoResponse(TestConstants.INSTAGRAM_ACCOUNT_DATA));
     });
 });

--- a/src/test/requests/page/linked_instagram_account/GetLinkedInstagramAccountRequest.test.ts
+++ b/src/test/requests/page/linked_instagram_account/GetLinkedInstagramAccountRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetLinkedInstagramAccountRequest } from '../../../../main/requests/page/linked_instagram_account/GetLinkedInstagramAccountRequest';
 import { GetLinkedInstagramAccountResponse } from '../../../../main/requests/page/linked_instagram_account/GetLinkedInstagramAccountResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -16,12 +14,10 @@ describe('GetLinkedInstagramAccountRequest', () => {
         expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}`);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}`).reply(200, TestConstants.LINKED_INSTAGRAM_ACCOUNT);
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify(TestConstants.LINKED_INSTAGRAM_ACCOUNT));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetLinkedInstagramAccountResponse(TestConstants.LINKED_INSTAGRAM_ACCOUNT));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetLinkedInstagramAccountResponse(TestConstants.LINKED_INSTAGRAM_ACCOUNT));
     });
 });

--- a/src/test/requests/page/media/GetPageMediaRequest.test.ts
+++ b/src/test/requests/page/media/GetPageMediaRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { PrivateMediaField, PublicMediaField } from '../../../../main/Enums';
 import { GetPageMediaRequest } from '../../../../main/requests/page/media/GetPageMediaRequest';
 import { GetPageMediaResponse } from '../../../../main/requests/page/media/GetPageMediaResponse';
@@ -28,17 +26,17 @@ describe('GetPageMediaRequest', () => {
         expect(requestAllFields.config().params.fields).toEqual(Utils.getAllMediaFields().join(','));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, {
-        data: [TestConstants.PARTIAL_MEDIA_DATA],
-        paging: TestConstants.PAGING,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: [TestConstants.PARTIAL_MEDIA_DATA],
+            paging: TestConstants.PAGING,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new GetPageMediaResponse({ data: [TestConstants.PARTIAL_MEDIA_DATA], paging: TestConstants.PAGING })
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(
+            new GetPageMediaResponse({ data: [TestConstants.PARTIAL_MEDIA_DATA], paging: TestConstants.PAGING })
+        );
     });
 });

--- a/src/test/requests/page/media/PostPageCarouselMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPageCarouselMediaRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
 import { PostPageCarouselMediaRequest } from '../../../../main/requests/page/media/PostPageCarouselMediaRequest';
 import { TestConstants } from '../../../TestConstants';
@@ -59,12 +57,10 @@ describe('PostPageCaroulselMediaRequest.', () => {
         expect(request.config().params.children).toEqual(TestConstants.ID_ARRAY.slice(1));
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, { id: TestConstants.CONTAINER_ID });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify({ id: TestConstants.CONTAINER_ID }));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
     });
 });

--- a/src/test/requests/page/media/PostPagePhotoMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPagePhotoMediaRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
 import { PostPagePhotoMediaRequest } from '../../../../main/requests/page/media/PostPagePhotoMediaRequest';
 import { TestConstants } from '../../../TestConstants';
@@ -49,12 +47,10 @@ describe('PostPagePhotoMediaRequest.', () => {
         expect(requestBare.config().params.is_carousel).toBeTruthy();
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, { id: TestConstants.CONTAINER_ID });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify({ id: TestConstants.CONTAINER_ID }));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
     });
 });

--- a/src/test/requests/page/media/PostPageReelMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPageReelMediaRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
 import { PostPageReelMediaRequest } from '../../../../main/requests/page/media/PostPageReelMediaRequest';
 import { TestConstants } from '../../../TestConstants';
@@ -49,12 +47,10 @@ describe('PostPageReelMediaRequest.', () => {
         expect(request.config().params.share_to_feed).toEqual(TestConstants.SHARE_TO_FEED);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, { id: TestConstants.CONTAINER_ID });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify({ id: TestConstants.CONTAINER_ID }));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
     });
 });

--- a/src/test/requests/page/media/PostPageStoriesPhotoMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPageStoriesPhotoMediaRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
 import { TestConstants } from '../../../TestConstants';
 import { PostPageStoriesVideoMediaRequest } from '../../../../main/requests/page/media/PostPageStoriesVideoMediaRequest';
@@ -18,12 +16,10 @@ describe('PostPageStoriesVideoMediaRequest.', () => {
         expect(request.config().params.video_url).toEqual(TestConstants.MEDIA_URL);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, { id: TestConstants.CONTAINER_ID });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify({ id: TestConstants.CONTAINER_ID }));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
     });
 });

--- a/src/test/requests/page/media/PostPageStoriesVideoMediaRequest.test.ts
+++ b/src/test/requests/page/media/PostPageStoriesVideoMediaRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
 import { PostPageStoriesPhotoMediaRequest } from '../../../../main/requests/page/media/PostPageStoriesPhotoMediaRequest';
 import { TestConstants } from '../../../TestConstants';
@@ -18,12 +16,10 @@ describe('PostPageStoriesPhotoMediaRequest.', () => {
         expect(request.config().params.image_url).toEqual(TestConstants.MEDIA_URL);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media`).reply(200, { id: TestConstants.CONTAINER_ID });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify({ id: TestConstants.CONTAINER_ID }));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.CONTAINER_ID }));
     });
 });

--- a/src/test/requests/page/media_publish/PostPublishMediaRequest.test.ts
+++ b/src/test/requests/page/media_publish/PostPublishMediaRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { CreatedObjectIdResponse } from '../../../../main/requests/common/CreatedObjectIdResponse';
 import { PostPublishMediaRequest } from '../../../../main/requests/page/media_publish/PostPublishMediaRequest';
 import { TestConstants } from '../../../TestConstants';
@@ -18,14 +16,14 @@ describe('PostPublishMediaRequest', () => {
         expect(request.config().params.creation_id).toEqual(TestConstants.CONTAINER_ID);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onPost(`${Constants.API_URL}/${TestConstants.PAGE_ID}/media_publish`).reply(200, {
-        id: TestConstants.MEDIA_ID,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            id: TestConstants.MEDIA_ID,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.MEDIA_ID }));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new CreatedObjectIdResponse({ id: TestConstants.MEDIA_ID }));
     });
 });

--- a/src/test/requests/page/recently_searched_hashtags/GetPageRecentlySearchedHashtagsRequest.test.ts
+++ b/src/test/requests/page/recently_searched_hashtags/GetPageRecentlySearchedHashtagsRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetPageRecentlySearchedHashtagsRequest } from '../../../../main/requests/page/recently_searched_hashtags/GetPageRecentlySearchedHashtagsRequest';
 import { TestConstants } from '../../../TestConstants';
 import { ManyIdsResponse } from '../../../../main/requests/common/ManyIdsResponse';
@@ -16,17 +14,17 @@ describe('GetPageRecentlySearchedHashtagsRequest', () => {
         expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}/recently_searched_hashtags`);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}/recently_searched_hashtags`).reply(200, {
-        data: [{ id: TestConstants.HASHTAG_ID }],
-        paging: TestConstants.PAGING,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: [{ id: TestConstants.HASHTAG_ID }],
+            paging: TestConstants.PAGING,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new ManyIdsResponse({ data: [{ id: TestConstants.HASHTAG_ID }], paging: TestConstants.PAGING })
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(
+            new ManyIdsResponse({ data: [{ id: TestConstants.HASHTAG_ID }], paging: TestConstants.PAGING })
+        );
     });
 });

--- a/src/test/requests/page/stories/GetPageStoriesRequest.test.ts
+++ b/src/test/requests/page/stories/GetPageStoriesRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetPageStoriesRequest } from '../../../../main/requests/page/stories/GetPageStoriesRequest';
 import { TestConstants } from '../../../TestConstants';
 import { ManyIdsResponse } from '../../../../main/requests/common/ManyIdsResponse';
@@ -13,17 +11,17 @@ describe('GetPageStoriesRequest', () => {
         expect(request.config().url).toEqual(`/${TestConstants.PAGE_ID}/stories`);
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}/stories`).reply(200, {
-        data: [{ id: TestConstants.MEDIA_ID }],
-        paging: TestConstants.PAGING,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: [{ id: TestConstants.MEDIA_ID }],
+            paging: TestConstants.PAGING,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new ManyIdsResponse({ data: [{ id: TestConstants.MEDIA_ID }], paging: TestConstants.PAGING })
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(
+            new ManyIdsResponse({ data: [{ id: TestConstants.MEDIA_ID }], paging: TestConstants.PAGING })
+        );
     });
 });

--- a/src/test/requests/page/tags/GetTagsRequest.test.ts
+++ b/src/test/requests/page/tags/GetTagsRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { PublicMediaField } from '../../../../main/Enums';
 import { GetTagsRequest } from '../../../../main/requests/page/tags/GetTagsRequest';
 import { GetTagsResponse } from '../../../../main/requests/page/tags/GetTagsResponse';
@@ -29,17 +27,17 @@ describe('GetTagsRequest', () => {
         );
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}/${TestConstants.PAGE_ID}/tags`).reply(200, {
-        data: [TestConstants.PARTIAL_MEDIA_DATA],
-        paging: TestConstants.PAGING,
-    });
-    it('Parses the response', () => {
+    fetchMock.mockOnce(
+        JSON.stringify({
+            data: [TestConstants.PARTIAL_MEDIA_DATA],
+            paging: TestConstants.PAGING,
+        })
+    );
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(
-                new GetTagsResponse({ data: [TestConstants.PARTIAL_MEDIA_DATA], paging: TestConstants.PAGING })
-            );
-        });
+        const response = await request.execute();
+        expect(response).toEqual(
+            new GetTagsResponse({ data: [TestConstants.PARTIAL_MEDIA_DATA], paging: TestConstants.PAGING })
+        );
     });
 });

--- a/src/test/requests/page/user_long_lived_token/GetUserLongLivedTokenRequest.test.ts
+++ b/src/test/requests/page/user_long_lived_token/GetUserLongLivedTokenRequest.test.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { Constants } from '../../../../main/Constants';
+import fetchMock from 'jest-fetch-mock';
 import { GetUserLongLivedTokenRequest } from '../../../../main/requests/page/user_long_lived_token/GetUserLongLivedTokenRequest';
 import { GetUserLongLivedTokenResponse } from '../../../../main/requests/page/user_long_lived_token/GetUserLongLivedTokenResponse';
 import { TestConstants } from '../../../TestConstants';
@@ -26,12 +24,10 @@ describe('GetUserLongLivedTokenRequest', () => {
         expect(request.config().url).toEqual(buildUrl());
     });
 
-    const mock = new MockAdapter(axios);
-    mock.onGet(`${Constants.API_URL}${buildUrl()}`).reply(200, TestConstants.USER_LONG_LIVED_TOKEN_DATA);
-    it('Parses the response', () => {
+    fetchMock.mockOnce(JSON.stringify(TestConstants.USER_LONG_LIVED_TOKEN_DATA));
+    it('Parses the response', async () => {
         expect.assertions(1);
-        return request.execute().then((response) => {
-            expect(response).toEqual(new GetUserLongLivedTokenResponse(TestConstants.USER_LONG_LIVED_TOKEN_DATA));
-        });
+        const response = await request.execute();
+        expect(response).toEqual(new GetUserLongLivedTokenResponse(TestConstants.USER_LONG_LIVED_TOKEN_DATA));
     });
 });


### PR DESCRIPTION
Removes Axios as it was quite heavy on the install size and overkill for this lib.

BREAKING CHANGE: Since Axios has been removed, error handling with `AxiosError` will no longer work and should be done in accordance with the native Node `fetch`.