### PR TITLE
chore: remove deprecated methods for paging, range and limit

### DIFF
--- a/src/main/requests/AbstractRequest.ts
+++ b/src/main/requests/AbstractRequest.ts
@@ -78,43 +78,6 @@ export abstract class AbstractRequest<R extends AbstractResponse<unknown>> {
      *
      * @param pageOptionToken the page option token to create the param.
      *
-     * @deprecated since 1.7.0, use {@link AbstractRequest#withPaging} instead.
-     */
-    public addPaging(pageOptionToken: PageOptionToken): void {
-        this.params.before = undefined;
-        this.params.after = undefined;
-        this.params[pageOptionToken.option] = pageOptionToken.value;
-    }
-
-    /**
-     * Adds the range params to the request.
-     *
-     * @param since the since param.
-     * @param until the until param.
-     *
-     * @deprecated since 1.7.0, use {@link AbstractRequest#withRange} instead.
-     */
-    public addRange(since: Date, until: Date): void {
-        this.params.since = since;
-        this.params.until = until;
-    }
-
-    /**
-     * Adds the limit param to the request.
-     *
-     * @param limit the number of objects to retrieve.
-     *
-     * @deprecated since 1.7.0, use {@link AbstractRequest#withLimit} instead.
-     */
-    public addLimit(limit: number): void {
-        this.params.limit = limit;
-    }
-
-    /**
-     * Adds a paging param to the request.
-     *
-     * @param pageOptionToken the page option token to create the param.
-     *
      * @returns this request, for use in chain invocation.
      */
     public withPaging(pageOptionToken: PageOptionToken): this {

--- a/src/test/requests/AbstractRequest.test.ts
+++ b/src/test/requests/AbstractRequest.test.ts
@@ -1,3 +1,4 @@
+import fetchMock from 'jest-fetch-mock';
 import { Constants } from '../../main/Constants';
 import { ApiVersion } from '../../main/Enums';
 import { AbstractRequest } from '../../main/requests/AbstractRequest';
@@ -28,7 +29,6 @@ describe('AbstractRequest', () => {
     const request: AbstractRequestImpl = new AbstractRequestImpl();
 
     fetchMock.mockOnce(JSON.stringify(TestConstants.FULL_MEDIA_DATA));
-
     it('Executes the request', async () => {
         const response = await request.execute();
         expect(response.getData()).toEqual(TestConstants.FULL_MEDIA_DATA);
@@ -43,29 +43,6 @@ describe('AbstractRequest', () => {
             url: TestConstants.PATH,
             baseURL: `${Constants.API_URL}/`,
         });
-    });
-
-    it('Adds the paging (deprecated method)', () => {
-        request.addPaging(TestConstants.BEFORE_PAGE);
-        expect(request.config().params.before).toEqual(TestConstants.BEFORE_PAGE.value);
-        request.addPaging(TestConstants.AFTER_PAGE);
-        expect(request.config().params.after).toEqual(TestConstants.AFTER_PAGE.value);
-
-        // Test that it clears the previous paging
-        expect(request.config().params.before).toBeUndefined();
-        request.addPaging(TestConstants.BEFORE_PAGE);
-        expect(request.config().params.after).toBeUndefined();
-    });
-
-    it('Adds the range (deprecated method)', () => {
-        request.addRange(TestConstants.SINCE, TestConstants.UNTIL);
-        expect(request.config().params.since).toEqual(TestConstants.SINCE);
-        expect(request.config().params.until).toEqual(TestConstants.UNTIL);
-    });
-
-    it('Adds the limit (deprecated method)', () => {
-        request.addLimit(TestConstants.LIMIT);
-        expect(request.config().params.limit).toEqual(TestConstants.LIMIT);
     });
 
     it('Adds the paging', () => {


### PR DESCRIPTION
The methods `addPaging()`, `addRange()` and `addLimit()` have been deprecated for a long time and it's time to remove them.

BREAKING CHANGE: `addPaging()`, `addRange()` and `addLimit()` are no longer available and should be replaced with `withPaging()`, `withRange()` and `withLimit()`